### PR TITLE
feat: allow users delete media

### DIFF
--- a/apps/cms/src/app/(app)/[workspace]/layout.tsx
+++ b/apps/cms/src/app/(app)/[workspace]/layout.tsx
@@ -1,5 +1,3 @@
-import PageLoader from "@/components/shared/page-loader";
-
 export default function WorkspaceLayout({
   children,
 }: {

--- a/apps/cms/src/app/(app)/[workspace]/media/page-client.tsx
+++ b/apps/cms/src/app/(app)/[workspace]/media/page-client.tsx
@@ -1,8 +1,9 @@
 "use client";
 
+import { DeleteMediaModal } from "@/components/media/delete-modal";
 import { MediaUploadModal } from "@/components/media/upload-modal";
 import { Button } from "@marble/ui/components/button";
-import { ImageIcon, UploadCloud } from "lucide-react";
+import { ImageIcon, Trash2, UploadCloud } from "lucide-react";
 import { useState } from "react";
 
 type Media = {
@@ -18,17 +19,15 @@ interface PageClientProps {
 function PageClient({ media }: PageClientProps) {
   const [optimisticMedia, setOptimisticMedia] = useState<Media[]>(media);
   const [showUploadModal, setShowUploadModal] = useState(false);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [mediaToDelete, setMediaToDelete] = useState<Media | null>(null);
 
   return (
     <>
       <div className="h-full flex flex-col mx-auto pt-10 pb-16 max-w-4xl gap-8">
         <section className="flex justify-between items-center">
           <div />
-          <Button
-            size="sm"
-            variant="outline"
-            onClick={() => setShowUploadModal(true)}
-          >
+          <Button size="sm" onClick={() => setShowUploadModal(true)}>
             <UploadCloud size={16} />
             <span>upload image</span>
           </Button>
@@ -38,8 +37,19 @@ function PageClient({ media }: PageClientProps) {
             {optimisticMedia.map((media) => (
               <li
                 key={media.id}
-                className="relative rounded-md overflow-hidden border"
+                className="relative rounded-md overflow-hidden border group"
               >
+                <button
+                  type="button"
+                  onClick={() => {
+                    setMediaToDelete(media);
+                    setShowDeleteModal(true);
+                  }}
+                  className="absolute top-2 right-2 p-2 bg-white rounded-full text-muted-foreground hover:text-destructive opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition duration-500"
+                >
+                  <Trash2 className="size-4" />
+                  <span className="sr-only">delete image</span>
+                </button>
                 <div className="">
                   <img
                     src={media.url}
@@ -49,7 +59,7 @@ function PageClient({ media }: PageClientProps) {
                 </div>
                 <div className="p-4 bg-background border-t">
                   <p className="text-sm text-muted-foreground truncate">
-                    {media.name}
+                    {media.name.split(".")[0]}
                   </p>
                 </div>
               </li>
@@ -58,7 +68,7 @@ function PageClient({ media }: PageClientProps) {
         ) : (
           <div className="grid h-full w-full place-content-center mt-10">
             <div className="flex flex-col items-center gap-4 max-w-80">
-              <ImageIcon className="size-16 stroke-[1px]" />
+              <ImageIcon className="size-16 stroke-[1px] text-muted-foreground" />
               <p className="text-balance text-center text-muted-foreground text-sm">
                 Images you upload in this workspace will appear here.
               </p>
@@ -75,6 +85,16 @@ function PageClient({ media }: PageClientProps) {
           }
         }}
       />
+      {mediaToDelete && (
+        <DeleteMediaModal
+          isDeleteDialogOpen={showDeleteModal}
+          setIsDeleteDialogOpen={setShowDeleteModal}
+          onDelete={(id) => {
+            setOptimisticMedia(optimisticMedia.filter((m) => m.id !== id));
+          }}
+          mediaToDelete={mediaToDelete.id}
+        />
+      )}
     </>
   );
 }

--- a/apps/cms/src/app/(app)/[workspace]/media/page.tsx
+++ b/apps/cms/src/app/(app)/[workspace]/media/page.tsx
@@ -17,11 +17,7 @@ async function Page({ params }: { params: Promise<{ workspace: string }> }) {
       url: true,
     },
   });
-  return (
-    <div>
-      <PageClient media={media} />
-    </div>
-  );
+  return <PageClient media={media} />;
 }
 
 export default Page;

--- a/apps/cms/src/components/editor/image-upload-modal.tsx
+++ b/apps/cms/src/components/editor/image-upload-modal.tsx
@@ -2,7 +2,7 @@
 
 import { CloudUpload, ImageIcon, Loader2, Trash2 } from "lucide-react";
 
-import { uploadImageAction } from "@/lib/actions/upload";
+import { uploadImageAction } from "@/lib/actions/media";
 import { Button } from "@marble/ui/components/button";
 import {
   Dialog,

--- a/apps/cms/src/components/editor/publish-setings.tsx
+++ b/apps/cms/src/components/editor/publish-setings.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { uploadImageAction } from "@/lib/actions/upload";
+import { uploadImageAction } from "@/lib/actions/media";
 import type { PostValues } from "@/lib/validations/post";
 import { Button } from "@marble/ui/components/button";
 import { Calendar } from "@marble/ui/components/calendar";

--- a/apps/cms/src/components/media/delete-modal.tsx
+++ b/apps/cms/src/components/media/delete-modal.tsx
@@ -1,0 +1,82 @@
+import { deleteMediaAction } from "@/lib/actions/media";
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@marble/ui/components/alert-dialog";
+import { Button } from "@marble/ui/components/button";
+import { toast } from "@marble/ui/components/sonner";
+import { Loader2 } from "lucide-react";
+import React, { useState } from "react";
+
+interface DeleteMediaModalProps {
+  isDeleteDialogOpen: boolean;
+  setIsDeleteDialogOpen: (isOpen: boolean) => void;
+  mediaToDelete: string;
+  onDelete: (id: string) => void;
+}
+
+export function DeleteMediaModal({
+  isDeleteDialogOpen,
+  setIsDeleteDialogOpen,
+  onDelete,
+  mediaToDelete,
+}: DeleteMediaModalProps) {
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleDelete = async () => {
+    try {
+      setIsLoading(true);
+      const result = await deleteMediaAction(mediaToDelete);
+      onDelete(result.id);
+      if (result.success) {
+        toast.success("Image deleted.");
+        setIsDeleteDialogOpen(false);
+      }
+    } catch (error) {
+      console.error(error);
+      toast.error("Failed to delete");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div>
+      <AlertDialog
+        open={isDeleteDialogOpen}
+        onOpenChange={setIsDeleteDialogOpen}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete this image?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Deleting this image will break posts where it is being used.
+              Please make sure to update all posts using this image.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            {/* <AlertDialogAction asChild> */}
+            <Button
+              onClick={handleDelete}
+              variant="destructive"
+              disabled={isLoading}
+            >
+              {isLoading ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                "Delete"
+              )}
+            </Button>
+            {/* </AlertDialogAction> */}
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/apps/cms/src/components/media/upload-modal.tsx
+++ b/apps/cms/src/components/media/upload-modal.tsx
@@ -2,7 +2,7 @@
 
 import { CloudUpload, ImageIcon, Trash2 } from "lucide-react";
 
-import { uploadImageAction } from "@/lib/actions/upload";
+import { uploadImageAction } from "@/lib/actions/media";
 import { Button } from "@marble/ui/components/button";
 import {
   Dialog,


### PR DESCRIPTION
## Description

This pr simply gives users the option to delete images they uploaded from the workspace

## Motivation and Context

- In the future users may be limited to the amount of images they can store or upload depending on their plan so deleting lets them free up some of that space
- also just because it wouldn't make sense not to give users that option

## Types of Changes

<!--- Mark all that apply with an `x` -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that alters existing functionality)
- [ ] 🎨 UI/UX Improvements
- [ ] ⚡ Performance Enhancement
- [ ] 📖 Documentation (updates to README, docs, or comments)
