### PR TITLE
fix: redirect to posts page

### DIFF
--- a/apps/cms/next.config.ts
+++ b/apps/cms/next.config.ts
@@ -2,6 +2,14 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   transpilePackages: ["@marble/db", "@marble/ui"],
+  rewrites: async () => {
+    return [
+      {
+        source: "/:workspace",
+        destination: "/:workspace/posts",
+      },
+    ];
+  },
   images: {
     remotePatterns: [
       {

--- a/apps/cms/src/components/nav/nav-main.tsx
+++ b/apps/cms/src/components/nav/nav-main.tsx
@@ -86,7 +86,7 @@ export function NavMain() {
     <SidebarGroup>
       <SidebarGroupLabel>Workspace</SidebarGroupLabel>
       <SidebarMenu>
-        <SidebarMenuButton
+        {/* <SidebarMenuButton
           asChild
           className={`border border-transparent transition-colors duration-200 hover:bg-sidebar-accent ${
             isOverviewActive
@@ -98,7 +98,7 @@ export function NavMain() {
             <Layout />
             <span>Overview</span>
           </Link>
-        </SidebarMenuButton>
+        </SidebarMenuButton> */}
         {items.map((item) => (
           <SidebarMenuButton
             asChild


### PR DESCRIPTION
Redirect to /posts while we work on the overview page!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Visiting a workspace URL now redirects to its Posts list, providing a clear default landing page and more consistent routing.
  - Sidebar streamlined by removing the “Overview” item; primary sections (Posts, Categories, Tags, Media, Team) remain accessible, and Settings is unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->