### PR TITLE
feat: display last used auth method

### DIFF
--- a/apps/cms/src/components/auth/login-form.tsx
+++ b/apps/cms/src/components/auth/login-form.tsx
@@ -10,9 +10,12 @@ import { Eye, EyeClosed, Spinner } from "@phosphor-icons/react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
+import { useLocalStorage } from "@/hooks/use-localstorage";
 import { authClient } from "@/lib/auth/client";
 import { type CredentialData, credentialSchema } from "@/lib/validations/auth";
+import type { AuthMethod } from "@/types/misc";
 import { Github, Google } from "../icons/social";
+import { LastUsedBadge } from "../ui/last-used-badge";
 
 export function LoginForm() {
   const {
@@ -26,7 +29,9 @@ export function LoginForm() {
   const [isGithubLoading, setIsGithubLoading] = useState(false);
   const [isCredentialsLoading, setIsCredentialsLoading] = useState(false);
   const [isPasswordVisible, setIsPasswordVisible] = useState(false);
-
+  const [lastUsedAuthMethod, setLastUsedAuthMethod] =
+    useLocalStorage<AuthMethod | null>("lastUsedAuthMethod", null);
+  console.log(lastUsedAuthMethod);
   const searchParams = useSearchParams();
   const router = useRouter();
   const callbackURL = searchParams?.get("from") || "/";
@@ -42,6 +47,7 @@ export function LoginForm() {
         },
         {
           onSuccess: (_ctx) => {
+            setLastUsedAuthMethod("email");
             toast.success("Welcome!");
             router.push(callbackURL);
           },
@@ -70,6 +76,7 @@ export function LoginForm() {
     } catch (_error) {
       return toast("Sign in failed. Please try again.");
     } finally {
+      setLastUsedAuthMethod(provider);
       provider === "google"
         ? setIsGoogleLoading(false)
         : setIsGithubLoading(false);
@@ -81,10 +88,17 @@ export function LoginForm() {
       <div className="grid grid-cols-2 gap-4">
         <button
           type="button"
-          className={cn(buttonVariants({ variant: "outline", size: "lg" }))}
+          className={cn(
+            buttonVariants({ variant: "outline", size: "lg" }),
+            "relative",
+          )}
           onClick={async () => handleSocialSignIn("google")}
           disabled={isCredentialsLoading || isGoogleLoading || isGithubLoading}
         >
+          <LastUsedBadge
+            show={lastUsedAuthMethod === "google"}
+            variant="primary"
+          />
           {isGoogleLoading ? (
             <Spinner className="mr-2 h-4 w-4 animate-spin" />
           ) : (
@@ -94,10 +108,17 @@ export function LoginForm() {
         </button>
         <button
           type="button"
-          className={cn(buttonVariants({ variant: "outline", size: "lg" }))}
+          className={cn(
+            buttonVariants({ variant: "outline", size: "lg" }),
+            "relative",
+          )}
           onClick={async () => handleSocialSignIn("github")}
           disabled={isCredentialsLoading || isGoogleLoading || isGithubLoading}
         >
+          <LastUsedBadge
+            show={lastUsedAuthMethod === "github"}
+            variant="primary"
+          />
           {isGithubLoading ? (
             <Spinner className="mr-2 h-4 w-4 animate-spin" />
           ) : (
@@ -176,8 +197,12 @@ export function LoginForm() {
             disabled={
               isCredentialsLoading || isGoogleLoading || isGithubLoading
             }
-            className="mt-4"
+            className={cn("mt-4", "relative")}
           >
+            <LastUsedBadge
+              show={lastUsedAuthMethod === "email"}
+              variant="secondary"
+            />
             {isCredentialsLoading && (
               <Spinner className="mr-2 h-4 w-4 animate-spin" />
             )}

--- a/apps/cms/src/components/auth/login-form.tsx
+++ b/apps/cms/src/components/auth/login-form.tsx
@@ -31,7 +31,6 @@ export function LoginForm() {
   const [isPasswordVisible, setIsPasswordVisible] = useState(false);
   const [lastUsedAuthMethod, setLastUsedAuthMethod] =
     useLocalStorage<AuthMethod | null>("lastUsedAuthMethod", null);
-  console.log(lastUsedAuthMethod);
   const searchParams = useSearchParams();
   const router = useRouter();
   const callbackURL = searchParams?.get("from") || "/";
@@ -59,7 +58,7 @@ export function LoginForm() {
         },
       );
     } catch (_error) {
-      return toast("Request failed. Please try again.");
+      return toast("Login failed. Please try again.");
     } finally {
       setIsCredentialsLoading(false);
     }

--- a/apps/cms/src/components/ui/last-used-badge.tsx
+++ b/apps/cms/src/components/ui/last-used-badge.tsx
@@ -1,0 +1,50 @@
+import { cn } from "@marble/ui/lib/utils";
+import { cva, type VariantProps } from "class-variance-authority";
+import type { HTMLAttributes } from "react";
+
+const lastUsedBadgeVariants = cva(
+  "absolute text-xs px-1.5 py-0.5 rounded-full font-medium",
+  {
+    variants: {
+      variant: {
+        primary: "bg-primary text-primary-foreground",
+        secondary: "bg-primary-foreground text-primary",
+      },
+      position: {
+        "top-right": "-top-2 -right-2",
+        "top-left": "-top-2 -left-2",
+      },
+    },
+    defaultVariants: {
+      variant: "primary",
+      position: "top-right",
+    },
+  },
+);
+
+export interface LastUsedBadgeProps
+  extends HTMLAttributes<HTMLSpanElement>,
+    VariantProps<typeof lastUsedBadgeVariants> {
+  show?: boolean;
+  text?: string;
+}
+
+export function LastUsedBadge({
+  className,
+  variant,
+  position,
+  show = false,
+  text = "LAST",
+  ...props
+}: LastUsedBadgeProps) {
+  if (!show) return null;
+
+  return (
+    <span
+      className={cn(lastUsedBadgeVariants({ variant, position }), className)}
+      {...props}
+    >
+      {text}
+    </span>
+  );
+}

--- a/apps/cms/src/types/misc.ts
+++ b/apps/cms/src/types/misc.ts
@@ -1,0 +1,1 @@
+export type AuthMethod = "google" | "github" | "email";


### PR DESCRIPTION
Display the last auth method the user has used to login with to make it easier to log into the correct account!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remembers your last-used sign-in method and highlights it with a persistent "LAST" badge on Google, GitHub, or Email buttons in both login and registration.

* **Style**
  * Added subtle "LAST" badges and minor layout adjustments for proper badge positioning.
  * Clarified email sign-in/sign-up error messages for clearer feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->