### PR TITLE
fix: check if user is part of workspace

### DIFF
--- a/apps/cms/src/app/api/workspaces/[slug]/route.ts
+++ b/apps/cms/src/app/api/workspaces/[slug]/route.ts
@@ -67,7 +67,10 @@ export async function GET(
     (member) => member.userId === sessionData.user.id,
   );
   if (!isUserMember) {
-    return NextResponse.json({ error: "User is not a member of the workspace" }, { status: 403 });
+    return NextResponse.json(
+      { error: "User is not a member of the workspace" },
+      { status: 403 },
+    );
   }
 
   // Find current user's role in this workspace


### PR DESCRIPTION
Check if the user actually belongs to the workspace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Enforces workspace membership before allowing access, preventing unauthorized viewing of workspace details.
  - Returns a clear 403 error when a user is not a member of the requested workspace.
  - Maintains existing response structure and role information for authorized users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->