### PR TITLE
feat: add image zoom and ui consistency

### DIFF
--- a/apps/cms/src/components/media/media-card.tsx
+++ b/apps/cms/src/components/media/media-card.tsx
@@ -8,6 +8,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@marble/ui/components/dropdown-menu";
+import { ImageZoom } from "@marble/ui/components/kibo-ui/image-zoom";
 import { toast } from "@marble/ui/components/sonner";
 import {
   DotsThreeVertical,
@@ -69,16 +70,16 @@ export function MediaCard({ media, onDelete }: MediaCardProps) {
       <CardContent className="p-0">
         <div className="aspect-video relative overflow-hidden">
           {media.type === "image" && (
-            // biome-ignore lint/performance/noImgElement: <>
-            <img
-              src={media.url}
-              alt={media.name}
-              className="object-cover w-full h-full"
-            />
+            <ImageZoom>
+              {/** biome-ignore lint/performance/noImgElement: <> */}
+              <img
+                src={media.url}
+                alt={media.name}
+                className="object-cover w-full h-full"
+              />
+            </ImageZoom>
           )}
-          {media.type === "video" && (
-            <VideoPlayer src={media.url} className="" />
-          )}
+          {media.type === "video" && <VideoPlayer src={media.url} />}
           {(media.type === "audio" || media.type === "document") && (
             <div className="w-full h-full flex items-center justify-center bg-muted">
               <Icon

--- a/apps/cms/src/components/media/media-gallery.tsx
+++ b/apps/cms/src/components/media/media-gallery.tsx
@@ -58,8 +58,8 @@ export function MediaGallery({ media }: MediaGalleryProps) {
       <section className="flex justify-between items-center">
         <div />
         <Button size="sm" onClick={() => setShowUploadModal(true)}>
-          <Upload size={16} className="" />
-          <span>upload media</span>
+          <Upload size={16} />
+          <span>Upload Media</span>
         </Button>
       </section>
       <ul className="grid grid-cols-[repeat(auto-fill,minmax(250px,1fr))] gap-4">

--- a/apps/cms/src/components/media/upload-modal.tsx
+++ b/apps/cms/src/components/media/upload-modal.tsx
@@ -65,7 +65,13 @@ export function MediaUploadModal({
   };
 
   return (
-    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        setIsOpen(open);
+        if (!open) setFile(undefined);
+      }}
+    >
       <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Upload Media</DialogTitle>
@@ -73,19 +79,19 @@ export function MediaUploadModal({
         <div className="flex flex-col gap-4 py-4">
           {file ? (
             <div className="flex flex-col gap-4">
-              <div className="relative w-full min-h-[500px]">
+              <div className="relative w-full h-[400px] flex items-center justify-center rounded-md overflow-hidden">
                 {file.type.startsWith("image/") ? (
                   // biome-ignore lint/performance/noImgElement: <>
                   <img
                     src={URL.createObjectURL(file)}
                     alt="cover preview"
-                    className="w-full h-full object-cover rounded-md"
+                    className="w-full h-full object-contain rounded-md"
                   />
                 ) : (
                   // biome-ignore lint/a11y/useMediaCaption: <>
                   <video
                     src={URL.createObjectURL(file)}
-                    className="w-full h-full object-cover rounded-md"
+                    className="w-full h-full object-contain rounded-md"
                     controls
                   />
                 )}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -45,6 +45,7 @@
     "next-themes": "^0.4.4",
     "react": "19.0.0",
     "react-day-picker": "9.8.1",
+    "react-medium-image-zoom": "^5.3.0",
     "sonner": "^1.7.1",
     "tailwind-merge": "^2.5.4",
     "tailwindcss-animate": "^1.0.7",

--- a/packages/ui/src/components/kibo-ui/image-zoom/index.tsx
+++ b/packages/ui/src/components/kibo-ui/image-zoom/index.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import Zoom, {
+  type ControlledProps,
+  type UncontrolledProps,
+} from 'react-medium-image-zoom';
+import { cn } from '@marble/ui/lib/utils';
+
+export type ImageZoomProps = UncontrolledProps & {
+  isZoomed?: ControlledProps['isZoomed'];
+  onZoomChange?: ControlledProps['onZoomChange'];
+  className?: string;
+  backdropClassName?: string;
+};
+
+export const ImageZoom = ({
+  className,
+  backdropClassName,
+  ...props
+}: ImageZoomProps) => (
+  <div
+    className={cn(
+      'relative',
+      '[&_[data-rmiz-ghost]]:pointer-events-none [&_[data-rmiz-ghost]]:absolute',
+      '[&_[data-rmiz-btn-zoom]]:m-0 [&_[data-rmiz-btn-zoom]]:size-10 [&_[data-rmiz-btn-zoom]]:touch-manipulation [&_[data-rmiz-btn-zoom]]:appearance-none [&_[data-rmiz-btn-zoom]]:rounded-[50%] [&_[data-rmiz-btn-zoom]]:border-none [&_[data-rmiz-btn-zoom]]:bg-foreground/70 [&_[data-rmiz-btn-zoom]]:p-2 [&_[data-rmiz-btn-zoom]]:text-background [&_[data-rmiz-btn-zoom]]:outline-offset-2',
+      '[&_[data-rmiz-btn-unzoom]]:m-0 [&_[data-rmiz-btn-unzoom]]:size-10 [&_[data-rmiz-btn-unzoom]]:touch-manipulation [&_[data-rmiz-btn-unzoom]]:appearance-none [&_[data-rmiz-btn-unzoom]]:rounded-[50%] [&_[data-rmiz-btn-unzoom]]:border-none [&_[data-rmiz-btn-unzoom]]:bg-foreground/70 [&_[data-rmiz-btn-unzoom]]:p-2 [&_[data-rmiz-btn-unzoom]]:text-background [&_[data-rmiz-btn-unzoom]]:outline-offset-2',
+      '[&_[data-rmiz-btn-zoom]:not(:focus):not(:active)]:pointer-events-none [&_[data-rmiz-btn-zoom]:not(:focus):not(:active)]:absolute [&_[data-rmiz-btn-zoom]:not(:focus):not(:active)]:size-px [&_[data-rmiz-btn-zoom]:not(:focus):not(:active)]:overflow-hidden [&_[data-rmiz-btn-zoom]:not(:focus):not(:active)]:whitespace-nowrap [&_[data-rmiz-btn-zoom]:not(:focus):not(:active)]:[clip-path:inset(50%)] [&_[data-rmiz-btn-zoom]:not(:focus):not(:active)]:[clip:rect(0_0_0_0)]',
+      '[&_[data-rmiz-btn-zoom]]:absolute [&_[data-rmiz-btn-zoom]]:top-2.5 [&_[data-rmiz-btn-zoom]]:right-2.5 [&_[data-rmiz-btn-zoom]]:bottom-auto [&_[data-rmiz-btn-zoom]]:left-auto [&_[data-rmiz-btn-zoom]]:cursor-zoom-in',
+      '[&_[data-rmiz-btn-unzoom]]:absolute [&_[data-rmiz-btn-unzoom]]:top-5 [&_[data-rmiz-btn-unzoom]]:right-5 [&_[data-rmiz-btn-unzoom]]:bottom-auto [&_[data-rmiz-btn-unzoom]]:left-auto [&_[data-rmiz-btn-unzoom]]:z-[1] [&_[data-rmiz-btn-unzoom]]:cursor-zoom-out',
+      '[&_[data-rmiz-content="found"]_img]:cursor-zoom-in',
+      '[&_[data-rmiz-content="found"]_svg]:cursor-zoom-in',
+      '[&_[data-rmiz-content="found"]_[role="img"]]:cursor-zoom-in',
+      '[&_[data-rmiz-content="found"]_[data-zoom]]:cursor-zoom-in',
+      className
+    )}
+  >
+    <Zoom
+      classDialog={cn(
+        '[&::backdrop]:hidden',
+        '[&[open]]:fixed [&[open]]:m-0 [&[open]]:h-dvh [&[open]]:max-h-none [&[open]]:w-dvw [&[open]]:max-w-none [&[open]]:overflow-hidden [&[open]]:border-0 [&[open]]:bg-transparent [&[open]]:p-0',
+        '[&_[data-rmiz-modal-overlay]]:absolute [&_[data-rmiz-modal-overlay]]:inset-0 [&_[data-rmiz-modal-overlay]]:transition-all',
+        '[&_[data-rmiz-modal-overlay="hidden"]]:bg-transparent',
+        '[&_[data-rmiz-modal-overlay="visible"]]:bg-background/80 [&_[data-rmiz-modal-overlay="visible"]]:backdrop-blur-md',
+        '[&_[data-rmiz-modal-content]]:relative [&_[data-rmiz-modal-content]]:size-full',
+        '[&_[data-rmiz-modal-img]]:absolute [&_[data-rmiz-modal-img]]:origin-top-left [&_[data-rmiz-modal-img]]:cursor-zoom-out [&_[data-rmiz-modal-img]]:transition-transform',
+        'motion-reduce:[&_[data-rmiz-modal-img]]:transition-none motion-reduce:[&_[data-rmiz-modal-overlay]]:transition-none',
+        backdropClassName
+      )}
+      {...props}
+    />
+  </div>
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -459,6 +459,9 @@ importers:
       react-day-picker:
         specifier: 9.8.1
         version: 9.8.1(react@19.0.0)
+      react-medium-image-zoom:
+        specifier: ^5.3.0
+        version: 5.3.0(react-dom@19.1.1(react@19.0.0))(react@19.0.0)
       sonner:
         specifier: ^1.7.1
         version: 1.7.1(react-dom@19.1.1(react@19.0.0))(react@19.0.0)
@@ -6030,6 +6033,12 @@ packages:
     peerDependencies:
       '@types/react': 19.0.2
       react: '>=16'
+
+  react-medium-image-zoom@5.3.0:
+    resolution: {integrity: sha512-RCIzVlsKqy3BYgGgYbolUfuvx0aSKC7YhX/IJGEp+WJxsqdIVYJHkBdj++FAj6VD7RiWj6VVmdCfa/9vJE9hZg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   react-moveable@0.56.0:
     resolution: {integrity: sha512-FmJNmIOsOA36mdxbrc/huiE4wuXSRlmon/o+/OrfNhSiYYYL0AV5oObtPluEhb2Yr/7EfYWBHTxF5aWAvjg1SA==}
@@ -14233,6 +14242,11 @@ snapshots:
       vfile: 5.3.7
     transitivePeerDependencies:
       - supports-color
+
+  react-medium-image-zoom@5.3.0(react-dom@19.1.1(react@19.0.0))(react@19.0.0):
+    dependencies:
+      react: 19.0.0
+      react-dom: 19.1.1(react@19.0.0)
 
   react-moveable@0.56.0:
     dependencies:


### PR DESCRIPTION
Slightly improves the media page by adding zoom to images, properly handle modal closing and by making the casing consistent with the rest of the app!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added zoom-on-click for images in media cards.

- Style
  - Upload button label updated to “Upload Media.”
  - Upload preview redesigned: shorter height, centered content, rounded corners, and clipped overflow.
  - Image/video previews now fit within the area without cropping.

- Bug Fixes
  - Cleaned up minor visual inconsistencies in media rendering (e.g., unnecessary classes).

- Chores
  - Added a new UI dependency to enable image zoom functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->