### PR TITLE
Remove margin for trach icon

### DIFF
--- a/apps/cms/src/components/posts/table-actions.tsx
+++ b/apps/cms/src/components/posts/table-actions.tsx
@@ -42,7 +42,7 @@ export default function PostTableActions(props: Post) {
             variant="destructive"
             onClick={() => setShowDeleteModal(true)}
           >
-            <TrashIcon className="size-4 mr-1.5" /> <span>Delete</span>
+            <TrashIcon size={16} /> <span>Delete</span>
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>


### PR DESCRIPTION
## Description
This PR removes the `size-4 mr-1.5` classes and replaces them with `size={16}`.

## Motivation and Context
The trash icon in the Delete option of the dropdown had unnecessary extra margin.  
This change cleans up the spacing and makes the icons consistent.

## How to Test
1. Open the dropdown menu by clicking the ellipses button.  
2. Check the Edit and Delete options.  
3. Confirm the trash icon is properly aligned without extra margin.

## Screenshots (if applicable)
N/A

## Video Demo (if applicable)
N/A

## Types of Changes
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that alters existing functionality)
- [x] 🎨 UI/UX Improvements
- [ ] ⚡ Performance Enhancement
- [ ] 📖 Documentation (updates to README, docs, or comments)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Delete action’s icon to use a fixed size for a more consistent look.
  * Refined spacing between the icon and the “Delete” label for a cleaner, more compact layout.
  * Visual-only adjustment; no changes to behavior or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->