### PR TITLE
feat: add analytics middleware to api

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,12 +1,12 @@
 import { Hono } from "hono";
 import { trimTrailingSlash } from "hono/trailing-slash";
+import { analytics } from "./middleware/analytics";
 import { ratelimit } from "./middleware/ratelimit";
 import authorsRoutes from "./routes/authors";
 import categoriesRoutes from "./routes/categories";
 import postsRoutes from "./routes/posts";
 import tagsRoutes from "./routes/tags";
 import type { Env } from "./types/env";
-import { analytics } from "./middleware/analytics";
 
 const app = new Hono<{ Bindings: Env }>();
 const v1 = new Hono<{ Bindings: Env }>();

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -6,6 +6,7 @@ import categoriesRoutes from "./routes/categories";
 import postsRoutes from "./routes/posts";
 import tagsRoutes from "./routes/tags";
 import type { Env } from "./types/env";
+import { analytics } from "./middleware/analytics";
 
 const app = new Hono<{ Bindings: Env }>();
 const v1 = new Hono<{ Bindings: Env }>();
@@ -13,7 +14,8 @@ const v1 = new Hono<{ Bindings: Env }>();
 const staleTime = 3600;
 
 // Global Middleware
-app.use("*", ratelimit());
+app.use("/:workspaceId/*", ratelimit());
+app.use("/:workspaceId/*", analytics());
 app.use(trimTrailingSlash());
 
 app.use("*", async (c, next) => {

--- a/apps/api/src/middleware/analytics.ts
+++ b/apps/api/src/middleware/analytics.ts
@@ -1,0 +1,49 @@
+import { Redis } from "@upstash/redis/cloudflare";
+import type { Context, MiddlewareHandler, Next } from "hono";
+
+export const analytics = (): MiddlewareHandler => {
+  return async (c: Context, next: Next) => {
+    // Proceed to the next middleware or route handler first
+    // to avoid delaying the response
+    await next();
+
+    const redisClient = new Redis({
+      url: c.env.REDIS_URL,
+      token: c.env.REDIS_TOKEN,
+    });
+
+    const url = new URL(c.req.url);
+    const pathParts = url.pathname.split("/").filter(Boolean);
+
+    let workspaceId: string | null = null;
+    if (pathParts.length >= 2 && pathParts[0] === "v1") {
+      workspaceId = pathParts[1];
+    } else if (pathParts.length > 0) {
+      workspaceId = pathParts[0];
+    }
+
+    const currentDate = new Date();
+    const dailyKey = currentDate.toISOString().split("T")[0];
+    const monthlyKey = currentDate.toISOString().slice(0, 7);
+
+    if (workspaceId) {
+      await redisClient.hincrby(
+        `analytics:workspace:${workspaceId}`,
+        "pageViews",
+        1,
+      );
+
+      await redisClient.hincrby(
+        `analytics:workspace:${workspaceId}:daily`,
+        dailyKey,
+        1,
+      );
+
+      await redisClient.hincrby(
+        `analytics:workspace:${workspaceId}:monthly`,
+        monthlyKey,
+        1,
+      );
+    }
+  };
+};

--- a/apps/api/src/middleware/analytics.ts
+++ b/apps/api/src/middleware/analytics.ts
@@ -22,20 +22,12 @@ export const analytics = (): MiddlewareHandler => {
       workspaceId = pathParts[0];
     }
 
-    const currentDate = new Date();
-    const dailyKey = currentDate.toISOString().split("T")[0];
-    const monthlyKey = currentDate.toISOString().slice(0, 7);
+    const monthlyKey =  new Date().toISOString().slice(0, 7);
 
     if (workspaceId) {
       await redisClient.hincrby(
         `analytics:workspace:${workspaceId}`,
         "pageViews",
-        1,
-      );
-
-      await redisClient.hincrby(
-        `analytics:workspace:${workspaceId}:daily`,
-        dailyKey,
         1,
       );
 

--- a/apps/api/src/middleware/analytics.ts
+++ b/apps/api/src/middleware/analytics.ts
@@ -22,7 +22,7 @@ export const analytics = (): MiddlewareHandler => {
       workspaceId = pathParts[0];
     }
 
-    const monthlyKey =  new Date().toISOString().slice(0, 7);
+    const monthlyKey = new Date().toISOString().slice(0, 7);
 
     if (workspaceId) {
       await redisClient.hincrby(


### PR DESCRIPTION
Allows us to track total and monthly api requests so we can enforce limits properly and show analytics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enabled workspace-level analytics to count page views.
  - Added monthly aggregation of page views per workspace.

- Chores
  - Scoped global middleware to workspace routes for both rate limiting and analytics, leaving health endpoints unchanged.
  - Ordered middleware to run analytics after rate limiting and before URL normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->