### PR TITLE
fix: make page headings consistent

### DIFF
--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -227,7 +227,7 @@ import { APP, FAQs, PRICING, SITE, USERS } from "@/lib/constants";
                       <>
                         <div class="flex flex-col gap-4">
                           <h3 class="text-medium text-2xl">{plan.title}</h3>
-                          <div class="">
+                          <div>
                             <p><span class="font-bold text-2xl">{plan.price.monthly}</span>{' '}<span>per month.</span></p>
                             <p class="text-muted-foreground text-sm">{plan.description}</p>
                           </div>

--- a/apps/web/src/pages/pricing/index.astro
+++ b/apps/web/src/pages/pricing/index.astro
@@ -13,7 +13,7 @@ import { PRICING, PRICING_FAQS, SITE } from "@/lib/constants";
         <Container class="space-y-10 lg:space-y-16 pt-12 pb-20 lg:py-24 ">
           <div class="relative flex flex-col items-center space-y-4">
             <h1 class="relative text-center text-balance text-2xl tracking-tight md:text-3xl lg:text-4xl max-w-4xl">
-              Pricing.
+              Pricing
             </h1>
             <p class="max-w-prose Md:text-lg text-muted-foreground text-center">
               Simple pricing, cancel anytime.

--- a/apps/web/src/pages/privacy/index.astro
+++ b/apps/web/src/pages/privacy/index.astro
@@ -33,7 +33,7 @@ const formattedDate = new Date(entry.data.lastUpdated).toLocaleDateString(
     <Container class="pt-14 pb-32">
     <div class='max-w-2xl mx-auto mb-10 space-y-2'>
       <h1 class='text-2xl sm:text-3xl md:text-4xl text-center'>
-        Privacy Policy.
+        Privacy Policy
       </h1>
       <p class="text-center text-muted-foreground">Last updated: {formattedDate}</p>
     </div>

--- a/apps/web/src/pages/terms/index.astro
+++ b/apps/web/src/pages/terms/index.astro
@@ -33,7 +33,7 @@ const formattedDate = new Date(entry.data.lastUpdated).toLocaleDateString(
     <Container class="pt-14 pb-32">
     <div class='max-w-2xl mx-auto mb-10 space-y-2'>
       <h1 class='text-2xl sm:text-3xl md:text-4xl text-center'>
-        Terms of service.
+        Terms of service
       </h1>
       <p class="text-center text-muted-foreground">Last updated: {formattedDate}</p>
     </div>


### PR DESCRIPTION
In a previous PR the dot after headings were removed however that wasn't updated on all pages. Fixed that for the sake of consistency and  also removed an empty class!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized page headings by removing trailing periods on Pricing, Privacy Policy, and Terms of Service pages for a cleaner, consistent look.
  * Minor markup cleanup in a pricing card by removing an unnecessary empty class attribute to reduce noise and improve maintainability.
  * No functional changes; purely presentational polish that improves readability and aligns typography across the site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->