### PR TITLE
feat: add syntax highlighting to codeblocks

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,6 +17,7 @@
     "astro": "^5.13.6",
     "free-astro-components": "^1.2.0",
     "sharp": "^0.34.3",
+    "shiki": "^3.12.2",
     "tailwindcss": "^4.1.12"
   },
   "devDependencies": {

--- a/apps/web/src/content.config.ts
+++ b/apps/web/src/content.config.ts
@@ -1,5 +1,6 @@
 import { defineCollection, z } from "astro:content";
 import { glob } from "astro/loaders";
+import { highlightContent } from "./lib/highlight";
 
 const key = import.meta.env.MARBLE_WORKSPACE_KEY;
 const url = import.meta.env.MARBLE_API_URL;
@@ -48,9 +49,12 @@ const articleCollection = defineCollection({
     const posts = data.posts as Post[];
     // Must return an array of entries with an id property
     // or an object with IDs as keys and entries as values
-    return posts.map((post) => ({
-      ...post,
-    }));
+    return Promise.all(
+      posts.map(async (post) => ({
+        ...post,
+        content: await highlightContent(post.content),
+      })),
+    );
   },
   schema: postSchema,
 });

--- a/apps/web/src/lib/highlight.ts
+++ b/apps/web/src/lib/highlight.ts
@@ -34,8 +34,8 @@ async function getHighlighter() {
 export async function highlightContent(htmlContent: string): Promise<string> {
   const highlighter = await getHighlighter();
 
-  // Marble returns the language as a class attribute on the <pre> tag
-  // i.e <pre class="language-jsx"><code>...</code></pre>
+  // Marble returns the language as a class attribute on the <code> tag
+  // i.e <pre><code class="language-jsx">...</code></pre>
   // so we use a regex to find and pick the language from the classname
   const codeBlockRegex =
     /<pre><code(?:\s+class="language-([^"]+)")?[^>]*>([\s\S]*?)<\/code><\/pre>/g;

--- a/apps/web/src/lib/highlight.ts
+++ b/apps/web/src/lib/highlight.ts
@@ -36,7 +36,7 @@ export async function highlightContent(htmlContent: string): Promise<string> {
 
   // Marble returns the language as a class attribute on the <pre> tag
   // i.e <pre class="language-jsx"><code>...</code></pre>
-  // so we use a regex to find and pick the language from the class attribute
+  // so we use a regex to find and pick the language from the classname
   const codeBlockRegex =
     /<pre><code(?:\s+class="language-([^"]+)")?[^>]*>([\s\S]*?)<\/code><\/pre>/g;
 

--- a/apps/web/src/lib/highlight.ts
+++ b/apps/web/src/lib/highlight.ts
@@ -1,0 +1,73 @@
+import { createHighlighter } from "shiki";
+
+// Create highlighter instance
+// Should be a singleton
+// https://shiki.style/guide/install#highlighter-usage
+let highlighter: Awaited<ReturnType<typeof createHighlighter>> | null = null;
+
+async function getHighlighter() {
+  if (!highlighter) {
+    highlighter = await createHighlighter({
+      themes: ["github-dark"],
+      langs: [
+        "javascript",
+        "typescript",
+        "json",
+        "html",
+        "css",
+        "bash",
+        "shell",
+        "jsx",
+        "tsx",
+        "markdown",
+        "yaml",
+        "xml",
+      ],
+    });
+  }
+  return highlighter;
+}
+
+/**
+ * Transform content from Marble to add syntax highlighting to code blocks
+ */
+export async function highlightContent(htmlContent: string): Promise<string> {
+  const highlighter = await getHighlighter();
+
+  // Marble returns the language as a class attribute on the <pre> tag
+  // i.e <pre class="language-jsx"><code>...</code></pre>
+  // so we use a regex to find and pick the language from the class attribute
+  const codeBlockRegex =
+    /<pre><code(?:\s+class="language-([^"]+)")?[^>]*>([\s\S]*?)<\/code><\/pre>/g;
+
+  return htmlContent.replace(codeBlockRegex, (match, language, code) => {
+    try {
+      // Decode HTML entities in the code
+      const decodedCode = code
+        .replace(/&lt;/g, "<")
+        .replace(/&gt;/g, ">")
+        .replace(/&amp;/g, "&")
+        .replace(/&quot;/g, '"')
+        .replace(/&#39;/g, "'");
+
+      // Use detected language or default to text if none specified
+      const lang = language || "text";
+
+      // Check if the language is supported
+      const supportedLanguages = highlighter.getLoadedLanguages();
+      const finalLang = supportedLanguages.includes(lang) ? lang : "text";
+
+      // https://shiki.style/guide/install#usage
+      const highlighted = highlighter.codeToHtml(decodedCode, {
+        lang: finalLang,
+        theme: "github-dark",
+      });
+
+      return highlighted;
+    } catch (error) {
+      console.warn("Failed to highlight code block:", error);
+      // We return the original content if highlighting fails
+      return match;
+    }
+  });
+}

--- a/apps/web/src/lib/highlight.ts
+++ b/apps/web/src/lib/highlight.ts
@@ -57,7 +57,6 @@ export async function highlightContent(htmlContent: string): Promise<string> {
       const supportedLanguages = highlighter.getLoadedLanguages();
       const finalLang = supportedLanguages.includes(lang) ? lang : "text";
 
-      // https://shiki.style/guide/install#usage
       const highlighted = highlighter.codeToHtml(decodedCode, {
         lang: finalLang,
         theme: "github-dark",

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -4,8 +4,30 @@
 @plugin "@tailwindcss/typography";
 @config "../../tailwind.config.ts";
 
+@font-face {
+  font-family: "Manrope";
+  src: url("/fonts/Manrope-Variable.ttf") format("truetype");
+  font-weight: 100 900;
+  font-style: normal;
+  font-display: swap;
+}
+@font-face {
+  font-family: "Funnel-Sans";
+  src: url("/fonts/FunnelSans-Variable.ttf") format("truetype");
+  font-weight: 100 900;
+  font-style: normal;
+  font-display: swap;
+}
+@font-face {
+  font-family: "Literata";
+  src: url("/fonts/Literata-Variable.ttf") format("truetype");
+  font-weight: 100 900;
+  font-style: normal;
+  font-display: swap;
+}
+
 :root {
-  --background: hsl(60, 11%, 98%);
+  --background: hsl(60 11% 98%);
   --foreground: hsl(240 15% 14%);
   --primary: hsl(240 10% 14%);
   --primary-foreground: hsl(0 0% 98%);
@@ -71,30 +93,6 @@
 @utility prose {
   & li p {
     margin: 0;
-  }
-}
-
-@layer base {
-  @font-face {
-    font-family: "Manrope";
-    src: url("/fonts/Manrope-Variable.ttf") format("truetype");
-    font-weight: 100 900;
-    font-style: normal;
-    font-display: swap;
-  }
-  @font-face {
-    font-family: "Funnel-Sans";
-    src: url("/fonts/FunnelSans-Variable.ttf") format("truetype");
-    font-weight: 100 900;
-    font-style: normal;
-    font-display: swap;
-  }
-  @font-face {
-    font-family: "Literata";
-    src: url("/fonts/Literata-Variable.ttf") format("truetype");
-    font-weight: 100 900;
-    font-style: normal;
-    font-display: swap;
   }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -335,6 +335,9 @@ importers:
       sharp:
         specifier: ^0.34.3
         version: 0.34.3
+      shiki:
+        specifier: ^3.12.2
+        version: 3.12.2
       tailwindcss:
         specifier: ^4.1.12
         version: 4.1.12
@@ -3118,38 +3121,20 @@ packages:
   '@shikijs/core@3.12.2':
     resolution: {integrity: sha512-L1Safnhra3tX/oJK5kYHaWmLEBJi1irASwewzY3taX5ibyXyMkkSDZlq01qigjryOBwrXSdFgTiZ3ryzSNeu7Q==}
 
-  '@shikijs/core@3.8.0':
-    resolution: {integrity: sha512-gWt8NNZFurL6FMESO4lEsmspDh0H1fyUibhx1NnEH/S3kOXgYiWa6ZFqy+dcjBLhZqCXsepuUaL1QFXk6PrpsQ==}
-
   '@shikijs/engine-javascript@3.12.2':
     resolution: {integrity: sha512-Nm3/azSsaVS7hk6EwtHEnTythjQfwvrO5tKqMlaH9TwG1P+PNaR8M0EAKZ+GaH2DFwvcr4iSfTveyxMIvXEHMw==}
-
-  '@shikijs/engine-javascript@3.8.0':
-    resolution: {integrity: sha512-IBULFFpQ1N5Cg/C7jPCGnjIKz72CcRtD0BIbNhSuXPUOxLG0bF1URsP/uLfxQFQ9ORfunCQwL7UuSX1RSRBwUQ==}
 
   '@shikijs/engine-oniguruma@3.12.2':
     resolution: {integrity: sha512-hozwnFHsLvujK4/CPVHNo3Bcg2EsnG8krI/ZQ2FlBlCRpPZW4XAEQmEwqegJsypsTAN9ehu2tEYe30lYKSZW/w==}
 
-  '@shikijs/engine-oniguruma@3.8.0':
-    resolution: {integrity: sha512-Tx7kR0oFzqa+rY7t80LjN8ZVtHO3a4+33EUnBVx2qYP3fGxoI9H0bvnln5ySelz9SIUTsS0/Qn+9dg5zcUMsUw==}
-
   '@shikijs/langs@3.12.2':
     resolution: {integrity: sha512-bVx5PfuZHDSHoBal+KzJZGheFuyH4qwwcwG/n+MsWno5cTlKmaNtTsGzJpHYQ8YPbB5BdEdKU1rga5/6JGY8ww==}
-
-  '@shikijs/langs@3.8.0':
-    resolution: {integrity: sha512-mfGYuUgjQ5GgXinB5spjGlBVhG2crKRpKkfADlp8r9k/XvZhtNXxyOToSnCEnF0QNiZnJjlt5MmU9PmhRdwAbg==}
 
   '@shikijs/themes@3.12.2':
     resolution: {integrity: sha512-fTR3QAgnwYpfGczpIbzPjlRnxyONJOerguQv1iwpyQZ9QXX4qy/XFQqXlf17XTsorxnHoJGbH/LXBvwtqDsF5A==}
 
-  '@shikijs/themes@3.8.0':
-    resolution: {integrity: sha512-yaZiLuyO23sXe16JFU76KyUMTZCJi4EMQKIrdQt7okoTzI4yAaJhVXT2Uy4k8yBIEFRiia5dtD7gC1t8m6y3oQ==}
-
   '@shikijs/types@3.12.2':
     resolution: {integrity: sha512-K5UIBzxCyv0YoxN3LMrKB9zuhp1bV+LgewxuVwHdl4Gz5oePoUFrr9EfgJlGlDeXCU1b/yhdnXeuRvAnz8HN8Q==}
-
-  '@shikijs/types@3.8.0':
-    resolution: {integrity: sha512-I/b/aNg0rP+kznVDo7s3UK8jMcqEGTtoPDdQ+JlQ2bcJIyu/e2iRvl42GLIDMK03/W1YOHOuhlhQ7aM+XbKUeg==}
 
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
@@ -6523,9 +6508,6 @@ packages:
   shiki@3.12.2:
     resolution: {integrity: sha512-uIrKI+f9IPz1zDT+GMz+0RjzKJiijVr6WDWm9Pe3NNY6QigKCfifCEv9v9R2mDASKKjzjQ2QpFLcxaR3iHSnMA==}
 
-  shiki@3.8.0:
-    resolution: {integrity: sha512-yPqK0y68t20aakv+3aMTpUMJZd6UHaBY2/SBUDowh9M70gVUwqT0bf7Kz5CWG0AXfHtFvXCHhBBHVAzdp0ILoQ==}
-
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -7438,7 +7420,7 @@ snapshots:
       remark-parse: 11.0.0
       remark-rehype: 11.1.2
       remark-smartypants: 3.0.2
-      shiki: 3.8.0
+      shiki: 3.12.2
       smol-toml: 1.4.2
       unified: 11.0.5
       unist-util-remove-position: 5.0.0
@@ -10792,22 +10774,9 @@ snapshots:
       '@types/hast': 3.0.4
       hast-util-to-html: 9.0.5
 
-  '@shikijs/core@3.8.0':
-    dependencies:
-      '@shikijs/types': 3.8.0
-      '@shikijs/vscode-textmate': 10.0.2
-      '@types/hast': 3.0.4
-      hast-util-to-html: 9.0.5
-
   '@shikijs/engine-javascript@3.12.2':
     dependencies:
       '@shikijs/types': 3.12.2
-      '@shikijs/vscode-textmate': 10.0.2
-      oniguruma-to-es: 4.3.3
-
-  '@shikijs/engine-javascript@3.8.0':
-    dependencies:
-      '@shikijs/types': 3.8.0
       '@shikijs/vscode-textmate': 10.0.2
       oniguruma-to-es: 4.3.3
 
@@ -10816,33 +10785,15 @@ snapshots:
       '@shikijs/types': 3.12.2
       '@shikijs/vscode-textmate': 10.0.2
 
-  '@shikijs/engine-oniguruma@3.8.0':
-    dependencies:
-      '@shikijs/types': 3.8.0
-      '@shikijs/vscode-textmate': 10.0.2
-
   '@shikijs/langs@3.12.2':
     dependencies:
       '@shikijs/types': 3.12.2
-
-  '@shikijs/langs@3.8.0':
-    dependencies:
-      '@shikijs/types': 3.8.0
 
   '@shikijs/themes@3.12.2':
     dependencies:
       '@shikijs/types': 3.12.2
 
-  '@shikijs/themes@3.8.0':
-    dependencies:
-      '@shikijs/types': 3.8.0
-
   '@shikijs/types@3.12.2':
-    dependencies:
-      '@shikijs/vscode-textmate': 10.0.2
-      '@types/hast': 3.0.4
-
-  '@shikijs/types@3.8.0':
     dependencies:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
@@ -15271,17 +15222,6 @@ snapshots:
       '@shikijs/langs': 3.12.2
       '@shikijs/themes': 3.12.2
       '@shikijs/types': 3.12.2
-      '@shikijs/vscode-textmate': 10.0.2
-      '@types/hast': 3.0.4
-
-  shiki@3.8.0:
-    dependencies:
-      '@shikijs/core': 3.8.0
-      '@shikijs/engine-javascript': 3.8.0
-      '@shikijs/engine-oniguruma': 3.8.0
-      '@shikijs/langs': 3.8.0
-      '@shikijs/themes': 3.8.0
-      '@shikijs/types': 3.8.0
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 


### PR DESCRIPTION
## Description

Just uses shiki to make codeblocks look nicer

## Motivation and Context

Cuz its cool

## How to Test

Make a post that includes a codeblock

## Screenshots (if applicable)

NO

## Types of Changes

<!--- Mark all that apply with an `x` -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that alters existing functionality)
- [x] 🎨 UI/UX Improvements
- [ ] ⚡ Performance Enhancement
- [ ] 📖 Documentation (updates to README, docs, or comments)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Articles now show rich syntax-highlighted code blocks for popular languages using a consistent dark theme.

- **Style**
  - Improved global font loading for Manrope, Funnel Sans, and Literata for faster, more consistent rendering.
  - Minor color token syntax cleanup for better CSS compatibility.

- **Chores**
  - Added a syntax-highlighting dependency to support the new code rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->