### PR TITLE
feat: allow exclude posts from their query

### DIFF
--- a/apps/api/src/routes/posts.ts
+++ b/apps/api/src/routes/posts.ts
@@ -19,6 +19,7 @@ posts.get("/", async (c) => {
       page: c.req.query("page"),
       order: c.req.query("order"),
       category: c.req.query("category"),
+      exclude: c.req.query("exclude"),
       tags: c.req.query("tags"),
       query: c.req.query("query"),
     });
@@ -41,6 +42,7 @@ posts.get("/", async (c) => {
       page,
       order,
       category,
+      exclude,
       tags = [],
       query,
     } = queryValidation.data;
@@ -50,6 +52,13 @@ posts.get("/", async (c) => {
       workspaceId,
       status: "published" as const,
       ...(category && { category: { slug: category } }),
+      ...(exclude && {
+        category: {
+          slug: {
+            not: exclude,
+          },
+        },
+      }),
       ...(tags.length > 0 && {
         tags: {
           some: {

--- a/apps/api/src/routes/posts.ts
+++ b/apps/api/src/routes/posts.ts
@@ -42,7 +42,7 @@ posts.get("/", async (c) => {
       page,
       order,
       category,
-      exclude,
+      exclude = [],
       tags = [],
       query,
     } = queryValidation.data;
@@ -51,14 +51,15 @@ posts.get("/", async (c) => {
     const where = {
       workspaceId,
       status: "published" as const,
-      ...(category && { category: { slug: category } }),
-      ...(exclude && {
-        category: {
-          slug: {
-            not: exclude,
-          },
-        },
-      }),
+      ...(() => {
+        if (category) {
+          return { category: { slug: category } };
+        }
+        if (exclude.length > 0) {
+          return { category: { slug: { notIn: exclude } } };
+        }
+        return {};
+      })(),
       ...(tags.length > 0 && {
         tags: {
           some: {

--- a/apps/api/src/validations.ts
+++ b/apps/api/src/validations.ts
@@ -22,6 +22,7 @@ export const PostsQuerySchema = z.object({
     .default("1"),
   order: OrderSchema,
   category: z.string().optional(),
+  exclude: z.string().optional(),
   tags: z
     .string()
     .transform((val) => val.split(",").filter(Boolean))

--- a/apps/api/src/validations.ts
+++ b/apps/api/src/validations.ts
@@ -22,7 +22,15 @@ export const PostsQuerySchema = z.object({
     .default("1"),
   order: OrderSchema,
   category: z.string().optional(),
-  exclude: z.string().optional(),
+  exclude: z
+    .string()
+    .transform((val) =>
+      val
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean),
+    )
+    .optional(),
   tags: z
     .string()
     .transform((val) => val.split(",").filter(Boolean))

--- a/apps/web/src/components/PostCard.astro
+++ b/apps/web/src/components/PostCard.astro
@@ -24,7 +24,7 @@ const formattedDate = new Date(publishedAt).toLocaleDateString("en-US", {
   >
     <div class="w-full border rounded-md overflow-hidden group">
       <Image
-        src={coverImage}
+        src={coverImage || "/og-blog.webp"}
         alt={title}
         loading="eager"
         inferSize

--- a/apps/web/src/components/PostCard.astro
+++ b/apps/web/src/components/PostCard.astro
@@ -24,7 +24,7 @@ const formattedDate = new Date(publishedAt).toLocaleDateString("en-US", {
   >
     <div class="w-full border rounded-md overflow-hidden group">
       <Image
-        src={coverImage || "/og-blog.webp"}
+        src={coverImage || "/og-blog.jpg"}
         alt={title}
         loading="eager"
         inferSize

--- a/apps/web/src/content.config.ts
+++ b/apps/web/src/content.config.ts
@@ -4,20 +4,43 @@ import { highlightContent } from "./lib/highlight";
 const key = import.meta.env.MARBLE_WORKSPACE_KEY;
 const url = import.meta.env.MARBLE_API_URL;
 
+async function fetchPosts(queryParams = ""): Promise<Post[]> {
+  const fullUrl = `${url}/${key}/posts${queryParams}`;
+
+  try {
+    const response = await fetch(fullUrl);
+
+    if (!response.ok) {
+      console.error(`Failed to fetch posts from ${fullUrl}:`, {
+        status: response.status,
+        statusText: response.statusText,
+        url: fullUrl,
+      });
+      return [];
+    }
+
+    const data = await response.json();
+    return data.posts as Post[];
+  } catch (error) {
+    console.error(`Error fetching posts from ${fullUrl}:`, error);
+    return [];
+  }
+}
+
 const postSchema = z.object({
   id: z.string(),
   slug: z.string(),
   title: z.string(),
   content: z.string(),
   description: z.string(),
-  coverImage: z.string().url(),
+  coverImage: z.string().url().nullable().optional(),
   publishedAt: z.coerce.date(),
   updatedAt: z.coerce.date(),
   authors: z.array(
     z.object({
       id: z.string(),
       name: z.string(),
-      image: z.string().url(),
+      image: z.string().url().nullable().optional(),
     }),
   ),
   category: z.object({
@@ -43,9 +66,7 @@ type Post = z.infer<typeof postSchema>;
 
 const articleCollection = defineCollection({
   loader: async () => {
-    const response = await fetch(`${url}/${key}/posts?exclude=legal`);
-    const data = await response.json();
-    const posts = data.posts as Post[];
+    const posts = await fetchPosts("?exclude=legal");
     // Must return an array of entries with an id property
     // or an object with IDs as keys and entries as values
     return Promise.all(
@@ -60,9 +81,7 @@ const articleCollection = defineCollection({
 
 const page = defineCollection({
   loader: async () => {
-    const response = await fetch(`${url}/${key}/posts?category=legal`);
-    const data = await response.json();
-    const posts = data.posts as Post[];
+    const posts = await fetchPosts("?category=legal");
 
     return posts.map((post) => ({
       ...post,

--- a/apps/web/src/content/pages/privacy.md
+++ b/apps/web/src/content/pages/privacy.md
@@ -2,61 +2,88 @@
 title: Privacy Policy
 published: 2024-12-12
 description: Marble's Privacy Policy.
-lastUpdated: 2025-02-13
+lastUpdated: 2025-09-18
 ---
 
-Marble ("we," "our," or "us") is committed to protecting your privacy. This Privacy Policy outlines how we collect, use, and safeguard your information when you use our app ("the App").
+Marble ("we," "our," or "us") is committed to protecting your privacy. This Privacy Policy explains how we collect, use, and safeguard your information when you use our service ("the Service").
 
 ## 1. Information We Collect
 
-We only collect minimal information to provide and improve our service. Specifically:
+We collect only the information necessary to provide and improve our service:
 
-### a. Analytics Data
+### a. Account Information
 
-- **What we collect:** Non-identifiable information about page visits, such as page views, timestamps, and browser type. No personally identifiable information (PII) is collected.
+- **What we collect:** Basic details such as your name, email address, and OAuth provider IDs (e.g., Google, GitHub) when you sign up.
+- **Why we collect it:** To create and manage your account, authenticate you, and provide access to your workspaces.
+
+### b. Workspace Data
+
+- **What we collect:** Content you create within the Service (e.g., posts, tags, workspace metadata).
+- **Why we collect it:** To deliver the core functionality of the CMS and allow collaboration.
+
+### c. AI Features (Optional)
+
+- **What we process:** When you use our AI-powered features, your workspace data (e.g., “posts tagged ‘design’”) may be temporarily processed to generate responses.
+- **What we don’t do:** We do not use your data to train external AI models without your consent.
+
+### d. Analytics Data
+
+- **What we collect:** Non-identifiable usage data such as page views, timestamps, and browser type.
+- **Provider:** We use Databuddy.cc, a GDPR-compliant analytics provider that does not track individuals.
+- **Why we collect it:** To monitor performance and improve the Service.
 
 ## 2. How We Use Your Information
 
-We use the information collected for the following purposes:
+We use the collected information to:
 
-- To monitor and analyze app performance and usage trends.
-- To improve our app and user experience.
+- Provide and operate the Service.
+- Enable authentication and account management.
+- Deliver AI-powered features at your request.
+- Monitor performance and usage trends.
+- Comply with legal obligations.
 
-We do not sell, rent, or share your information with third parties for marketing or any other purpose.
+We do not sell or rent your information to third parties.
 
 ## 3. Data Sharing
 
-We do not share your data with any third parties, except as required by law or to comply with legal obligations.
+We may share your information with trusted service providers (e.g., hosting providers, analytics, payment processors, AI infrastructure) who help us operate the Service. These providers are bound by strict confidentiality and data protection obligations.
+
+We may also share data if required by law.
 
 ## 4. Data Retention
 
-We retain analytics data for as long as necessary to fulfill the purposes outlined in this policy. If you would like us to delete any collected data, please contact us at [support@marblecms.com](mailto:support@marblecms.com).
+- Account data is retained for as long as your account is active.
+- Workspace data is retained until you delete it or request deletion.
+- Analytics data is retained only as long as necessary for performance monitoring.
 
-## 5. Your Privacy Rights
+You may request deletion of your data at any time by contacting us at [support@marblecms.com](mailto:support@marblecms.com).
 
-Depending on your jurisdiction, you may have the following rights:
+## 5. Your Rights
 
-- **Access and Correction:** Request access to or correction of the data we have collected.
-- **Deletion:** Request deletion of your data (where applicable).
-- **Opt-out:** Opt-out of data collection, including analytics (if applicable).
+Depending on your jurisdiction (e.g., GDPR, CCPA), you may have the right to:
+
+- Access and receive a copy of your data.
+- Request correction or deletion of your data.
+- Restrict or object to certain processing.
+- Export your data in a portable format.
 
 To exercise these rights, contact us at [support@marblecms.com](mailto:support@marblecms.com).
 
 ## 6. Cookies and Tracking
 
-We do not use cookies or other tracking technologies. The only data collected is through our analytics service, which does not track individual users.
+We do not use cookies for tracking. Analytics is handled by Databuddy, which does not identify individual users.
 
 ## 7. Security Measures
 
-We take the security of your data seriously and implement industry-standard measures to protect it. However, no method of transmission over the Internet or electronic storage is completely secure, and we cannot guarantee absolute security.
+We use industry-standard measures, including encryption in transit and at rest, to protect your data. However, no system is 100% secure, and we cannot guarantee absolute protection.
 
-## 8. Changes to This Privacy Policy
+## 8. Changes to This Policy
 
-We may update this Privacy Policy from time to time. Any changes will be posted here, and we will notify users via the app or email (if applicable). Please review this Privacy Policy periodically for updates.
+We may update this Privacy Policy from time to time. If significant changes are made, we will notify you via the Service or email.
 
 ## 9. Contact Us
 
-If you have any questions or concerns about this Privacy Policy, please contact us at [support@marblecms.com](mailto:support@marblecms.com)
+If you have any questions or concerns, please contact us at: [support@marblecms.com](mailto:support@marblecms.com)
 
 ---
-By using the App, you acknowledge that you have read and understood this Privacy Policy.
+By using the Service, you acknowledge that you have read and understood this Privacy Policy.

--- a/apps/web/src/content/pages/terms.md
+++ b/apps/web/src/content/pages/terms.md
@@ -2,50 +2,94 @@
 title: Terms of Service
 published: 2024-12-12
 description: Marble's Terms of Service.
-lastUpdated: 2025-02-13
+lastUpdated: 2025-09-18
 ---
-
 
 ## 1. Acceptance of Terms
 
-By using marble ("the App"), you agree to these Terms of Service ("Terms"). If you do not agree, do not use the App.
+By accessing or using Marble ("the Service"), you agree to these Terms of Service ("Terms"). If you do not agree, do not use the Service.
 
-## 2. Use of the App
+## 2. Definitions
 
-- You should be 16 years or older to use the App.
-- You are responsible for maintaining the confidentiality of your account credentials.
+- **User:** An individual who creates an account or accesses the Service.
+- **Organization / Workspace:** A group account managed by one or more Users.
+- **Content:** Any data, text, images, or other materials uploaded or created through the Service.
+- **Subscription:** A paid plan granting access to certain features of the Service.
 
-## 3. Content Ownership
+## 3. Eligibility & Accounts
 
-You retain ownership of the content you create and manage within the App. By using the App, you grant us a non-exclusive license to store and display your content as necessary to provide the service.
+- You must be at least 16 years old to use the Service.
+- You are responsible for maintaining the confidentiality of your login credentials.
+- You agree to provide accurate information when creating an account or organization.
+- You are responsible for all activities under your account.
 
-## 4. Prohibited Activities
+## 4. Content Ownership & License
+
+- You retain ownership of all Content you create.
+- By using the Service, you grant Marble a non-exclusive, worldwide license to host, display, and process your Content as necessary to operate the Service.
+- You represent that you have the rights to any Content you upload.
+- Marble retains all rights, title, and interest in its software, trademarks, and intellectual property.
+
+## 5. Payments & Subscriptions
+
+- Some features require a paid Subscription.
+- Subscriptions are billed in advance on a recurring basis (monthly or yearly, as selected).
+- Payments are processed through third-party providers (e.g., Polar). Marble does not store payment card details.
+- All fees are non-refundable except as required by law.
+- If a payment fails, we may suspend or downgrade your access until payment is resolved.
+- We reserve the right to change pricing with reasonable prior notice.
+
+## 6. Prohibited Activities
 
 You agree not to:
 
-- Use the App for unlawful purposes.
+- Use the Service for unlawful purposes.
 - Upload malicious software or harmful content.
-- Attempt to access unauthorized features or systems.
+- Infringe on the rights of others, including intellectual property rights.
+- Attempt to gain unauthorized access to systems or data.
 
-## 5. Limitation of Liability
+## 7. Data & Privacy
 
-The App is provided "as is" without warranties of any kind. We are not liable for any damages resulting from your use of the App.
+- Your use of the Service is also governed by our [Privacy Policy](/privacy).
+- We may process personal data in accordance with applicable laws (e.g., GDPR, CCPA where applicable).
+- We do not sell your data. We may share data only with service providers necessary to operate the Service.
 
-## 6. Modifications to the Service
+## 8. Service Availability
 
-We reserve the right to modify or discontinue the App at any time without notice.
+- The Service is provided “as is” and “as available.”
+- We do not guarantee uninterrupted uptime or that the Service will be error-free.
+- We may modify, suspend, or discontinue the Service at any time without liability.
 
-## 7. Termination
+## 9. Indemnification
 
-We may suspend or terminate your access to the App for violations of these Terms.
+You agree to indemnify and hold harmless Marble, its affiliates, and its contributors from any claims, damages, liabilities, or expenses arising out of:
 
-## 8. Governing Law
+- Your use of the Service,
+- Your Content, or
+- Your violation of these Terms.
 
-These Terms are governed by the laws of the Federal Republic of Nigeria.
+## 10. Limitation of Liability
 
-## 9. Contact
+- To the maximum extent permitted by law, Marble shall not be liable for indirect, incidental, consequential, or punitive damages.
+- Marble’s total liability for any claim shall not exceed the amount you paid to us in the 12 months preceding the claim.
 
-For questions or concerns about these Terms, contact us at [support@marblecms.com](mailto:support@marblecms.com).
+## 11. Modifications to Terms
 
----
-By using the App, you agree to these Terms.
+- We may update these Terms from time to time.
+- We will notify you of material changes via email or in-app notice.
+- Continued use of the Service after changes take effect constitutes acceptance.
+
+## 12. Termination
+
+- We may suspend or terminate your account for violations of these Terms or misuse of the Service.
+- You may stop using the Service at any time.
+- Upon termination, your access will end but certain provisions (e.g., liability, ownership) will survive.
+
+## 13. Governing Law & Dispute Resolution
+
+- These Terms are governed by the laws of the Federal Republic of Nigeria, without regard to conflict-of-law rules.
+- Any disputes will be resolved through binding arbitration or mediation where permitted, or in the courts of Nigeria.
+
+## 14. Contact
+
+For questions or concerns about these Terms, contact us at: [support@marblecms.com](mailto:support@marblecms.com)

--- a/apps/web/src/pages/blog/[slug].astro
+++ b/apps/web/src/pages/blog/[slug].astro
@@ -47,7 +47,9 @@ const formattedDate = new Date(entry.data.publishedAt).toLocaleDateString(
           </div>
         </section>
         <div>
-          <Image src={entry.data.coverImage} alt={entry.data.title} class="w-full max-w-3xl mx-auto mb-8" inferSize />
+          {entry.data.coverImage && (
+            <Image src={entry.data.coverImage} alt={entry.data.title} class="w-full max-w-3xl mx-auto mb-8" inferSize />
+          )}
         </div>
         <Prose>
           <div set:html={entry.data.content} />

--- a/apps/web/src/pages/privacy/index.astro
+++ b/apps/web/src/pages/privacy/index.astro
@@ -1,5 +1,5 @@
 ---
-import { getEntry, render } from "astro:content";
+import { getEntry } from "astro:content";
 import Container from "@/components/Container.astro";
 import Prose from "@/components/Prose.astro";
 import Layout from "@/layouts/Layout.astro";
@@ -11,9 +11,7 @@ if (!entry) {
   throw new Error("Page not found");
 }
 
-const { Content } = await render(entry);
-
-const formattedDate = new Date(entry.data.lastUpdated).toLocaleDateString(
+const formattedDate = new Date(entry.data.updatedAt).toLocaleDateString(
   "en-US",
   {
     year: "numeric",
@@ -33,13 +31,13 @@ const formattedDate = new Date(entry.data.lastUpdated).toLocaleDateString(
     <Container class="pt-14 pb-32">
     <div class='max-w-2xl mx-auto mb-10 space-y-2'>
       <h1 class='text-2xl sm:text-3xl md:text-4xl text-center'>
-        Privacy Policy
+        Privacy Policy.
       </h1>
       <p class="text-center text-muted-foreground">Last updated: {formattedDate}</p>
     </div>
 
-    <Prose class="prose-sm max-w-(--breakpoint-sm)">
-      <Content />
+    <Prose>
+      <div set:html={entry.data.content} />
     </Prose>
   </Container>
   </div>

--- a/apps/web/src/pages/terms/index.astro
+++ b/apps/web/src/pages/terms/index.astro
@@ -1,5 +1,5 @@
 ---
-import { getEntry, render } from "astro:content";
+import { getEntry } from "astro:content";
 import Container from "@/components/Container.astro";
 import Prose from "@/components/Prose.astro";
 import Layout from "@/layouts/Layout.astro";
@@ -11,9 +11,7 @@ if (!entry) {
   throw new Error("Page not found");
 }
 
-const { Content } = await render(entry);
-
-const formattedDate = new Date(entry.data.lastUpdated).toLocaleDateString(
+const formattedDate = new Date(entry.data.updatedAt).toLocaleDateString(
   "en-US",
   {
     year: "numeric",
@@ -38,8 +36,8 @@ const formattedDate = new Date(entry.data.lastUpdated).toLocaleDateString(
       <p class="text-center text-muted-foreground">Last updated: {formattedDate}</p>
     </div>
 
-    <Prose class="prose-sm max-w-(--breakpoint-sm)">
-      <Content />
+    <Prose>
+      <div set:html={entry.data.content} />
     </Prose>
     </Container>
   </div>


### PR DESCRIPTION
## Description

This PR added an exclude param to the list of allowed query params allowing me to query all posts except a specific category

## Motivation and Context

Honestly just so i can use it for my legal pages

## How to Test

N/A

## Types of Changes

<!--- Mark all that apply with an `x` -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that alters existing functionality)
- [ ] 🎨 UI/UX Improvements
- [ ] ⚡ Performance Enhancement
- [ ] 📖 Documentation (updates to README, docs, or comments)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added an exclude filter to post listings to hide posts from specified categories.
  - Post schema now includes tags and attribution; cover and author images can be nullable.
  - Article feed now excludes legal content by default.

- Refactor
  - Privacy and Terms pages load content via the API and use updatedAt for dates.
  - Page entries now include stable IDs derived from post slugs and share the unified post schema.

- Bug Fixes
  - Post cards and post pages now handle missing cover images gracefully (fallbacks/conditional rendering).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->