### PR TITLE
fix(email): handled missing resend api key in dev and include user email in verify redirect

### DIFF
--- a/apps/cms/src/middleware.ts
+++ b/apps/cms/src/middleware.ts
@@ -53,9 +53,15 @@ export async function middleware(request: NextRequest) {
     }
 
     const callbackUrl = encodeURIComponent(request.nextUrl.pathname);
+
+    const email = session.user.email;
+
     // Redirect unverified users to verify page
     return NextResponse.redirect(
-      new URL(`/verify?from=${callbackUrl}`, request.url),
+      new URL(
+        `/verify?email=${encodeURIComponent(email)}&from=${callbackUrl}`,
+        request.url,
+      ),
     );
   }
 


### PR DESCRIPTION
## Description

This PR introduces a mock email service for the development environment and improves the email verification flow by ensuring the user's email is always present in the URL.

## Motivation and Context

- Dev Email Mock

Problem: The application would crash in a development environment if the RESEND_API_KEY was not configured, making it difficult for new contributors to get started and test features that involve email.

Solution: A new mock email service is introduced. In development mode, if RESEND_API_KEY is not present, the application will not throw an error. Instead, all email-sending requests will be logged to the console with the email details (recipient, subject, and data), allowing to test the email flow without a live API key. 

- Improved Email Verification Redirect

Problem: When an unverified user was redirected to the /verify page, If the user refreshed the page to another page(e.g homepage), they would be redirected back to the verify email page but the url would lose the email param, which causes otp not be sent.

Solution: The authentication middleware has been updated to include the user's email as a URL parameter in the redirect to the /verify page. This ensures the email is always available for the verification form, even after a page refresh.

## How to Test

- Dev Email Mock
 
Start the server without an API key: Ensure your .env file does not contain a RESEND_API_KEY.

Verify the server starts: Confirm that your development server starts up successfully and you do not see a "Missing API key" runtime error on your screen

Trigger an email action: Use the application to perform an action that sends an email (e.g., sign up for a new account or trigger a password reset).

Verify the console output: Check your terminal where the server is running. You should see a log in the terminal with the subject, recipient, and other email data, but no Resend API error.

- Improved Email Verification Redirect

Sign up as a new user: Create a new account with a valid email address. The application should automatically redirect you to the /verify page.

Check the URL: Confirm that the URL in your browser is similar to /verify?email=your.email@example.com.

Test the refresh: Refresh the page to the base url - / you'd get redirected to the /verify url, verify that the URL with the email parameter is still present.

Confirm functionality: Ensure the OTP is correctly sent to the email address in the URL, and you can complete the verification process.


## Types of Changes

<!--- Mark all that apply with an `x` -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that alters existing functionality)
- [ ] 🎨 UI/UX Improvements
- [ ] ⚡ Performance Enhancement
- [ ] 📖 Documentation (updates to README, docs, or comments)
