### PR TITLE
feat: add discord and onlyfans

### DIFF
--- a/apps/cms/src/lib/constants.ts
+++ b/apps/cms/src/lib/constants.ts
@@ -147,6 +147,8 @@ export const SOCIAL_PLATFORMS = {
   tiktok: "tiktok",
   linkedin: "linkedin",
   website: "website",
+  onlyfans: "onlyfans",
+  discord: "discord",
 } as const;
 
 export type SocialPlatform = keyof typeof SOCIAL_PLATFORMS;
@@ -159,4 +161,6 @@ export const PLATFORM_DOMAINS = {
   youtube: ["youtube.com", "youtu.be"],
   tiktok: ["tiktok.com"],
   linkedin: ["linkedin.com"],
+  onlyfans: ["onlyfans.com"],
+  discord: ["discord.com"],
 } as const;

--- a/apps/cms/src/utils/author.tsx
+++ b/apps/cms/src/utils/author.tsx
@@ -1,5 +1,7 @@
 import {
+  DiscordLogoIcon,
   FacebookLogoIcon,
+  FanIcon,
   GithubLogoIcon,
   GlobeHemisphereEastIcon,
   InstagramLogoIcon,
@@ -44,6 +46,8 @@ export function getPlatformDisplayName(platform: SocialPlatform): string {
     youtube: "YouTube",
     tiktok: "TikTok",
     linkedin: "LinkedIn",
+    onlyfans: "OnlyFans",
+    discord: "Discord",
     website: "Website",
   };
 
@@ -70,6 +74,10 @@ export const getPlatformIcon = (platform: SocialPlatform) => {
       return <GlobeHemisphereEastIcon {...iconProps} />;
     case "website":
       return <GlobeHemisphereEastIcon {...iconProps} />;
+    case "onlyfans":
+      return <FanIcon {...iconProps} />;
+    case "discord":
+      return <DiscordLogoIcon {...iconProps} />;
     default:
       return <GlobeHemisphereEastIcon {...iconProps} />;
   }


### PR DESCRIPTION
Adds discord and onlyfans support for social links on authors!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for OnlyFans and Discord as social platforms.
  * Authors can now add OnlyFans and Discord profiles to their social links.
  * Platform names and icons are displayed for OnlyFans and Discord.
  * Recognition and handling of OnlyFans and Discord links are now supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->