### PR TITLE
fix: send markdown to ai

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -18,7 +18,7 @@ jobs:
         name: Install pnpm
         
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --ignore-scripts
 
       - name: Run lint
         run: pnpm lint

--- a/apps/cms/package.json
+++ b/apps/cms/package.json
@@ -62,6 +62,7 @@
     "nanoid": "^5.0.9",
     "next": "15.5.4",
     "next-themes": "^0.4.4",
+    "node-html-markdown": "^1.3.0",
     "novel": "^0.5.0",
     "nuqs": "^2.6.0",
     "react": "^19.1.1",

--- a/apps/cms/src/app/api/ai/suggestions/prompt.ts
+++ b/apps/cms/src/app/api/ai/suggestions/prompt.ts
@@ -12,7 +12,7 @@ export const systemPrompt = ({ metrics }: SystemPromptParams) => {
   return `You are a professional writing coach specializing in readability improvement. Analyze the provided text and generate specific, actionable suggestions to improve its readability and clarity. Decide on a type of the post e.g. blog post, article, changelog, etc. If you can't decide go with the default blog post. Make sure you use this type to generate the suggestions e.g. a changelog will include a list of changes rather than text. Determine the main topic of the post and use it to generate the suggestions e.g. not every topic needs a professional writing style.
 
     <PROMPT>
-        <ANALYSIS-CRITERIA>
+        ## ANALYSIS-CRITERIA
         - Word count and content length optimization
         - Sentence length and complexity (flag sentences >20 words)
         - Word choice and vocabulary complexity  
@@ -23,24 +23,21 @@ export const systemPrompt = ({ metrics }: SystemPromptParams) => {
         - Text flow and logical progression
         - Redundancy and wordiness
         - Clarity and ambiguity issues
-        </ANALYSIS-CRITERIA>
 
-        <HEADING-STRUCTURE-RULES>
+        ## HEADING-STRUCTURE-RULES
         - Maximum 1 h1/# heading (should be the main title, so 0 in body text)
         - Proper hierarchy: h2/## follows h1/#, h3/### follows h2/##, etc.
         - No skipping levels (don't go from h2 to h4)
         - Check both HTML (<h1>, <h2>) and Markdown (#, ##) syntax
-        </HEADING-STRUCTURE-RULES>
 
-        <TEXT-METRICS-INPUT>
+        ## TEXT-METRICS-INPUT
         - Word count: ${metrics.wordCount}
         - Sentence count: ${metrics.sentenceCount}
         - Average words per sentence: ${metrics.wordsPerSentence}
         - Reading time: ${metrics.readingTime} minutes
         - Readability score: ${metrics.readabilityScore}
-        </TEXT-METRICS-INPUT>
 
-        <RESPONSE-REQUIREMENTS>
+        ## RESPONSE-REQUIREMENTS
         - Return maximum 8 suggestions
         - Each suggestion "text" must be 1-2 sentences only
         - Provide brief "explanation" when helpful (e.g., examples of complex words, specific improvements)
@@ -49,25 +46,20 @@ export const systemPrompt = ({ metrics }: SystemPromptParams) => {
         - Be specific and concrete, not generic. Make sure the suggestions are actionable and specific.
         - Focus on immediate improvements the writer can make
         - Don't use an em dash in the suggestions
-        </RESPONSE-REQUIREMENTS>
 
-        <EXPLANATION-GUIDELINES>
+        ## EXPLANATION-GUIDELINES
         - Keep explanations to 1 sentence maximum
         - Use when providing examples: "Complex words like 'utilize' could be 'use'"
         - Use when clarifying metrics: "Sentences averaging 20-25 words or more are considered hard to read"
         - Use when giving specific alternatives: "Try 'shows' instead of 'demonstrates'"
-        </EXPLANATION-GUIDELINES>
 
-        <TEXT-REFERENCE-GUIDELINES>
+        ## TEXT-REFERENCE-GUIDELINES
         - Include exact text snippets that need attention (for highlighting)
         - Only include if there's a specific problematic phrase or sentence
         - Keep references short (5-15 words max)
         - Examples: "utilize advanced methodologies", "In conclusion, it is evident that"
-        </TEXT-REFERENCE-GUIDELINES>
 
-        <CRITICAL> 
+        ## CRITICAL
         Only suggest real issues you can identify in the text. If the text is well-written, acknowledge it and provide minor refinement suggestions.
-        </CRITICAL>
-
     </PROMPT>`;
 };

--- a/apps/cms/src/app/api/ai/suggestions/route.tsx
+++ b/apps/cms/src/app/api/ai/suggestions/route.tsx
@@ -1,5 +1,6 @@
 import { db } from "@marble/db";
 import { NextResponse } from "next/server";
+import { NodeHtmlMarkdown } from "node-html-markdown";
 import { getServerSession } from "@/lib/auth/session";
 import { openrouter } from "@/lib/openrouter";
 import { aiSuggestionsRateLimiter, rateLimitHeaders } from "@/lib/ratelimit";
@@ -68,7 +69,7 @@ export async function POST(request: Request) {
         role: "user",
         content: `
         <CONTENT>
-        ${parsedBody.data.content}
+        ${NodeHtmlMarkdown.translate(parsedBody.data.content)}
         </CONTENT>
         `,
       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,6 +235,9 @@ importers:
       next-themes:
         specifier: ^0.4.4
         version: 0.4.4(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      node-html-markdown:
+        specifier: ^1.3.0
+        version: 1.3.0
       novel:
         specifier: ^0.5.0
         version: 0.5.0(@tiptap/extension-code-block@2.8.0(@tiptap/core@2.10.4(@tiptap/pm@2.8.0))(@tiptap/pm@2.8.0))(@types/react@19.0.2)(highlight.js@11.11.1)(lowlight@3.3.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)


### PR DESCRIPTION
Sends markdown instead of html to the ai, also makes the format workflow a bit faster by skipping postinstall scripts