### PR TITLE
fix error message

### DIFF
--- a/apps/cms/src/lib/validations/workspace.ts
+++ b/apps/cms/src/lib/validations/workspace.ts
@@ -29,7 +29,7 @@ export const workspaceSchema = z.object({
     .max(32, { message: "Name cannot be more than 32 characters" }),
   slug: z
     .string()
-    .min(4, { message: "Slug cannot be empty" })
+    .min(4, { message: "Slug must be at least 4 characters long" })
     .max(32, { message: "Slug cannot be more than 32 characters" })
     .regex(/^[a-z0-9]+([a-z0-9-]*[a-z0-9])?$/, {
       message:
@@ -57,7 +57,7 @@ export type NameValues = z.infer<typeof nameSchema>;
 export const slugSchema = z.object({
   slug: z
     .string()
-    .min(4, { message: "Slug cannot be empty" })
+    .min(4, { message: "Slug must be at least 4 characters long" })
     .max(32, { message: "Slug cannot be more than 32 characters" })
     .regex(/^[a-z0-9]+([a-z0-9-]*[a-z0-9])?$/, {
       message:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation feedback for slug fields across workspace-related forms. When the minimum length rule is violated, users now see "Slug must be at least 4 characters long" instead of the previous "Slug cannot be empty." This provides clearer guidance during form creation and editing, reducing confusion and helping users resolve validation errors more quickly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->