### PR TITLE
refactor: switch from lucide to phosphor

### DIFF
--- a/apps/cms/src/app/(auth)/join/[id]/page-client.tsx
+++ b/apps/cms/src/app/(auth)/join/[id]/page-client.tsx
@@ -15,7 +15,12 @@ import {
   CardTitle,
 } from "@marble/ui/components/card";
 import { cn } from "@marble/ui/lib/utils";
-import { CheckIcon, CircleNotchIcon, ArrowArcLeftIcon, XIcon } from "@phosphor-icons/react";
+import {
+  ArrowArcLeftIcon,
+  CheckIcon,
+  CircleNotchIcon,
+  XIcon,
+} from "@phosphor-icons/react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";

--- a/apps/cms/src/components/invoice/table-actions.tsx
+++ b/apps/cms/src/components/invoice/table-actions.tsx
@@ -5,7 +5,11 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@marble/ui/components/dropdown-menu";
-import { CopyIcon, DownloadSimpleIcon, DotsThreeIcon } from "@phosphor-icons/react";
+import {
+  CopyIcon,
+  DotsThreeIcon,
+  DownloadSimpleIcon,
+} from "@phosphor-icons/react";
 import { toast } from "sonner";
 import type { Invoice } from "./columns";
 

--- a/apps/cms/src/components/ui/data-table-pagination.tsx
+++ b/apps/cms/src/components/ui/data-table-pagination.tsx
@@ -6,13 +6,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@marble/ui/components/select";
-import type { Table } from "@tanstack/react-table";
 import {
-  CaretLeftIcon,
-  CaretRightIcon,
   CaretDoubleLeftIcon,
   CaretDoubleRightIcon,
+  CaretLeftIcon,
+  CaretRightIcon,
 } from "@phosphor-icons/react";
+import type { Table } from "@tanstack/react-table";
 
 type DataTablePaginationProps<TData> = {
   table: Table<TData>;

--- a/apps/cms/src/components/webhooks/create-webhook.tsx
+++ b/apps/cms/src/components/webhooks/create-webhook.tsx
@@ -22,9 +22,8 @@ import {
   SheetTrigger,
 } from "@marble/ui/components/sheet";
 import { toast } from "@marble/ui/components/sonner";
-import { BracketsCurlyIcon } from "@phosphor-icons/react";
+import { BracketsCurlyIcon, PlusIcon } from "@phosphor-icons/react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { PlusIcon } from "@phosphor-icons/react";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useId, useState } from "react";
 import { useForm } from "react-hook-form";


### PR DESCRIPTION
Switches most of the CMS over to phosphor besides the types and the ui package

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Refreshed iconography across the CMS for a more consistent look.
  - Join page: updated back navigation icon and loading spinner.
  - Invoice table: new icons for “more options,” download, and copy actions.
  - Data table pagination: replaced navigation icons with updated caret variants.
  - Webhooks: create button now uses a new plus icon.
  - No functional changes; visual clarity improved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->