### PR TITLE
docs: update contributing guide to include Redis and QStash setup ins…

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -9,9 +9,11 @@ Before you start, make sure you have the following installed or available:
 - **Node.js** ≥ 20.x
 - **pnpm** ≥ 8.x (install with `npm i -g pnpm`)
 - **PostgreSQL** database (we use [Neon](https://neon.tech) in examples)
+- **Redis** database (we use [Upstash](https://upstash.com) for serverless Redis)
 - **Google** and **GitHub** OAuth apps (for authentication)
 - **Cloudflare** account with R2 enabled (for media uploads)
 - **Optional**: [Polar](https://sandbox.polar.sh) sandbox account if you want to test payments
+- **Optional**: [QStash](https://upstash.com/qstash) for reliable webhook delivery
 
 ---
 
@@ -91,9 +93,11 @@ Packages contain internal shared modules used across different applications:
    cp packages/db/.env.example packages/db/.env
    ```
 
-   You’ll need:
+   You'll need:
 
    - A Postgres connection string (either neon or use docker to self host)
+
+   - Redis credentials from Upstash (see below)
 
    - Google and GitHub OAuth credentials (how to get these)
 
@@ -102,6 +106,8 @@ Packages contain internal shared modules used across different applications:
    - Cloudflare R2 credentials for file uploads (see below)
 
    - Optional: If you want to test payments, set up a [Polar](https://sandbox.polar.sh) sandbox account and fill in the POLAR_* variables.
+
+   - Optional: If you want to test webhook delivery, set up [QStash](https://upstash.com/qstash) and fill in the QSTASH_TOKEN variable.
 
 4. Database Setup
 
@@ -213,7 +219,54 @@ This will:
 
 - Leave everything else as default and click "Create user API Token"
 
-- Copy the values to `CLOUDFLARE_SECRET_ACCESS_KEY` and `CLOUDFLARE_ACCESS_KEY_ID` respectively  
+- Copy the values to `CLOUDFLARE_SECRET_ACCESS_KEY` and `CLOUDFLARE_ACCESS_KEY_ID` respectively
+
+### Set up Upstash Redis
+
+   Marble uses Redis for rate limiting, session caching, and analytics. We use [Upstash](https://upstash.com) for serverless Redis. Here's how to set it up:
+
+- Go to [Upstash Console](https://console.upstash.com) and sign in or create an account
+
+- Click "Create Database"
+
+- Give your database a name (e.g. marble-redis)
+
+- Select a region close to your primary deployment region
+
+- Leave the type as "Regional" (free tier)
+
+- Click "Create"
+
+- Once created, scroll down to the "REST API" section
+
+- Copy the "UPSTASH_REDIS_REST_URL" value and set it to `REDIS_URL` in your environment files
+
+- Copy the "UPSTASH_REDIS_REST_TOKEN" value and set it to `REDIS_TOKEN` in your environment files
+
+   You'll need to add these to:
+   - `apps/api/.dev.vars` → `REDIS_URL=<YOUR_URL_HERE>` and `REDIS_TOKEN=<YOUR_TOKEN_HERE>`
+   - `apps/cms/.env` → `REDIS_URL=<YOUR_URL_HERE>` and `REDIS_TOKEN=<YOUR_TOKEN_HERE>`
+
+### Set up QStash (Optional)
+
+   QStash provides reliable webhook delivery with automatic retries. This is optional but recommended for production-like webhook testing. QStash is also from [Upstash](https://upstash.com).
+
+- Go to [Upstash Console](https://console.upstash.com) (same account as Redis)
+
+- Click on "QStash" in the sidebar
+
+- If you haven't enabled QStash yet, click "Enable QStash"
+
+- Once enabled, you'll see your QStash dashboard
+
+- Scroll down to the "Request Builder" section and find "Current Signing Keys"
+
+- Copy the signing key token and set it to `QSTASH_TOKEN` in your environment files
+
+   You'll need to add this to:
+   - `apps/cms/.env` → `QSTASH_TOKEN=<YOUR_TOKEN_HERE>`
+
+   Note: QStash is used for reliable webhook delivery with automatic retries. Without it, webhooks will still work but won't have retry functionality.
 
 ## Running the Apps
 


### PR DESCRIPTION
## Description

This pr updates the contributing file to let contributors know they need redis and qstash

## Types of Changes

<!--- Mark all that apply with an `x` -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that alters existing functionality)
- [ ] 🎨 UI/UX Improvements
- [ ] ⚡ Performance Enhancement
- [x] 📖 Documentation (updates to README, docs, or comments)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributing guide to include Redis as a prerequisite and optional QStash for reliable webhook delivery.
  * Added step-by-step setup for Upstash Redis and QStash, including where to place REDIS_URL, REDIS_TOKEN, and QSTASH_TOKEN.
  * Clarified and reorganized key management instructions for clearer setup flow.
  * Added cross-references to ensure environment variables are configured across app configurations.
  * Minor copy edits and formatting for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->