### PR TITLE
feat(frontend): add create workspace dialog to workspace switcher

### DIFF
--- a/apps/cms/src/components/nav/create-workspace-dialog.tsx
+++ b/apps/cms/src/components/nav/create-workspace-dialog.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@marble/ui/components/dialog";
+import { Input } from "@marble/ui/components/input";
+import { Label } from "@marble/ui/components/label";
+import { toast } from "@marble/ui/components/sonner";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+import { Controller, useForm } from "react-hook-form";
+import { ErrorMessage } from "@/components/auth/error-message";
+import { AsyncButton } from "@/components/ui/async-button";
+import { TimezoneSelector } from "@/components/ui/timezone-selector";
+import { organization } from "@/lib/auth/client";
+import { timezones } from "@/lib/constants";
+import {
+  type CreateWorkspaceValues,
+  workspaceSchema,
+} from "@/lib/validations/workspace";
+import { generateSlug } from "@/utils/string";
+
+type CreateWorkspaceDialogProps = {
+  open: boolean;
+  setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
+export const CreateWorkspaceDialog = (props: CreateWorkspaceDialogProps) => {
+  const router = useRouter();
+
+  const {
+    register,
+    handleSubmit,
+    watch,
+    setValue,
+    control,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<CreateWorkspaceValues>({
+    resolver: zodResolver(workspaceSchema),
+    defaultValues: {
+      name: "",
+      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    },
+  });
+
+  const { name } = watch();
+
+  useEffect(() => {
+    if (name) {
+      const slug = generateSlug(name);
+      setValue("slug", slug);
+    }
+  }, [name, setValue]);
+
+  async function onSubmit(payload: CreateWorkspaceValues) {
+    const { error } = await organization.checkSlug({
+      slug: payload.slug,
+    });
+
+    if (error) {
+      toast.error(error.message);
+      return;
+    }
+
+    try {
+      const { data, error } = await organization.create({
+        name: payload.name,
+        slug: payload.slug,
+        timezone: payload.timezone,
+        logo: `https://api.dicebear.com/9.x/glass/svg?seed=${payload.name}`,
+      });
+
+      if (error) {
+        toast.error(error.message);
+        return;
+      }
+
+      if (data) {
+        await organization.setActive({
+          organizationId: data.id,
+        });
+        props.setOpen(false);
+        reset();
+        router.push(`/${data.slug}`);
+        toast.success("Workspace created");
+      }
+    } catch (error) {
+      console.error("Failed to create workspace", error);
+      toast.error("Failed to create workspace");
+    }
+  }
+
+  return (
+    <Dialog onOpenChange={props.setOpen} open={props.open}>
+      <DialogContent className="p-8 sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="text-center font-medium">
+            Create Workspace
+          </DialogTitle>
+          <DialogDescription className="text-center">
+            Set up your new workspace.
+          </DialogDescription>
+        </DialogHeader>
+        <form className="flex flex-col gap-5" onSubmit={handleSubmit(onSubmit)}>
+          <div className="flex flex-col gap-2">
+            <Label className="sr-only" htmlFor="name">
+              Name
+            </Label>
+            <Input id="name" placeholder="Name" {...register("name")} />
+            {errors.name && <ErrorMessage>{errors.name.message}</ErrorMessage>}
+          </div>
+
+          <div className="grid flex-1 gap-2">
+            <Label className="sr-only" htmlFor="slug">
+              Slug
+            </Label>
+            <div className="flex w-full overflow-hidden rounded-md border border-input bg-transparent text-base shadow-xs transition-[color,box-shadow] placeholder:text-muted-foreground focus-within:border-ring focus-within:ring-[3px] focus-within:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:bg-input/30">
+              <span className="border-r bg-muted p-2">
+                {process.env.NEXT_PUBLIC_APP_URL?.split("//")[1]}/
+              </span>
+              <input
+                id="slug"
+                placeholder="Slug"
+                {...register("slug")}
+                autoComplete="off"
+                className="w-full bg-transparent px-2 py-2 outline-none ring-0"
+              />
+            </div>
+            {errors.slug && <ErrorMessage>{errors.slug.message}</ErrorMessage>}
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <Label className="sr-only" htmlFor="timezone">
+              Timezone
+            </Label>
+            <Controller
+              control={control}
+              name="timezone"
+              render={({ field }) => (
+                <TimezoneSelector
+                  onValueChange={field.onChange}
+                  placeholder="Select timezone..."
+                  timezones={timezones}
+                  value={field.value}
+                />
+              )}
+            />
+            {errors.timezone && (
+              <ErrorMessage>{errors.timezone.message}</ErrorMessage>
+            )}
+          </div>
+
+          <AsyncButton
+            className="mt-4 flex w-full gap-2"
+            isLoading={isSubmitting}
+            type="submit"
+          >
+            Create
+          </AsyncButton>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/apps/cms/src/components/nav/workspace-switcher.tsx
+++ b/apps/cms/src/components/nav/workspace-switcher.tsx
@@ -24,9 +24,10 @@ import {
 import { Skeleton } from "@marble/ui/components/skeleton";
 import { cn } from "@marble/ui/lib/utils";
 import { CaretDownIcon, CheckIcon, PlusIcon } from "@phosphor-icons/react";
-import Link from "next/link";
+import { useState } from "react";
 import type { Workspace } from "@/types/workspace";
 import { useWorkspace } from "../../providers/workspace";
+import { CreateWorkspaceDialog } from "./create-workspace-dialog";
 
 export function WorkspaceSwitcher() {
   const { isMobile, state } = useSidebar();
@@ -37,6 +38,8 @@ export function WorkspaceSwitcher() {
     workspaceList,
     isFetchingWorkspace,
   } = useWorkspace();
+
+  const [dialogOpen, setDialogOpen] = useState(false);
 
   const ownedWorkspaces =
     workspaceList?.filter(
@@ -195,9 +198,10 @@ export function WorkspaceSwitcher() {
 
             <DropdownMenuSeparator />
             <DropdownMenuItem>
-              <Link
+              <button
                 className="flex w-full items-center gap-2"
-                href={`/new?workspaces=${workspaceList && workspaceList.length > 0}`}
+                onClick={() => setDialogOpen(true)}
+                type="button"
               >
                 <div className="flex size-6 items-center justify-center rounded-md border bg-background">
                   <PlusIcon className="size-4" />
@@ -205,10 +209,11 @@ export function WorkspaceSwitcher() {
                 <div className="font-medium text-muted-foreground">
                   Create Workspace
                 </div>
-              </Link>
+              </button>
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
+        <CreateWorkspaceDialog open={dialogOpen} setOpen={setDialogOpen} />
       </SidebarMenuItem>
     </SidebarMenu>
   );


### PR DESCRIPTION
## Description

Adds a "Create Workspace" dialog to the workspace switcher dropdown.

## Motivation and Context

Keeps users in context instead of navigating away to `/new` when creating a new workspace, and only redirects when there aren't any workspaces after deleting.

I would suggest another PR to rebuild how the main dashboard is, so you could do suspenses with empty data behind the dialog on like https://app.marblecms.com/ you can see the new dialog workspace that you can't escape.

## How to Test

1. Log in with an account that has at least one workspace
2. Click the workspace switcher in the sidebar
3. Click "Create Workspace" at the bottom of the dropdown
4. Verify a dialog opens with name, slug, and timezone fields
5. Fill in the form and submit
6. Verify the new workspace is created and you're redirected to it

## Types of Changes

<!--- Mark all that apply with an `x` -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that alters existing functionality)
- [x] 🎨 UI/UX Improvements
- [ ] ⚡ Performance Enhancement
- [ ] 📖 Documentation (updates to README, docs, or comments)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a modal dialog for creating new workspaces with form validation
  * Auto-generates workspace slug from the name input
  * Includes timezone selector for workspace configuration
  * Provides inline validation feedback and error messages
  * Toast notifications confirm successful workspace creation or display errors

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->