### PR TITLE
fix(cms): save tag description and remount modal on edit

### DIFF
--- a/apps/cms/src/components/tags/columns.tsx
+++ b/apps/cms/src/components/tags/columns.tsx
@@ -7,6 +7,7 @@ export type Tag = {
   id: string;
   name: string;
   slug: string;
+  description?: string | null;
   postsCount: number;
 };
 

--- a/apps/cms/src/components/tags/table-actions.tsx
+++ b/apps/cms/src/components/tags/table-actions.tsx
@@ -40,12 +40,14 @@ export default function TableActions(props: Tag) {
         </DropdownMenuContent>
       </DropdownMenu>
 
-      <TagModal
-        mode="update"
-        open={showUpdateModal}
-        setOpen={setShowUpdateModal}
-        tagData={{ ...props }}
-      />
+      {showUpdateModal && (
+        <TagModal
+          mode="update"
+          open={showUpdateModal}
+          setOpen={setShowUpdateModal}
+          tagData={{ ...props }}
+        />
+      )}
 
       <DeleteTagModal
         id={props.id}

--- a/apps/cms/src/components/tags/tag-modals.tsx
+++ b/apps/cms/src/components/tags/tag-modals.tsx
@@ -38,7 +38,7 @@ export function TagModal({
   open,
   setOpen,
   mode = "create",
-  tagData = { name: "", slug: "" },
+  tagData = { name: "", slug: "", description: "" },
   onTagCreated,
 }: {
   open: boolean;
@@ -57,7 +57,7 @@ export function TagModal({
     formState: { errors, isSubmitting },
   } = useForm<CreateTagValues>({
     resolver: zodResolver(tagSchema),
-    defaultValues: { name: tagData.name || "", slug: tagData.slug || "" },
+    defaultValues: { name: tagData.name || "", slug: tagData.slug || "", description: tagData.description || "" },
   });
 
   const { name } = watch();


### PR DESCRIPTION
## Description

- Added `description` field to Tag type and modal form defaults
- Fixed edit modal to remount on open for fresh data

## Motivation and Context

Tag description field existed in the UI but was never persisted, and edit modal showed stale data, same fix as #281 but for tags.

## How to Test

1. Create a tag with a description, then edit it to verify description is displayed and updates persist

## Types of Changes

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that alters existing functionality)
- [ ] 🎨 UI/UX Improvements
- [ ] ⚡ Performance Enhancement
- [ ] 📖 Documentation (updates to README, docs, or comments)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Tags now support an optional description field for enhanced documentation and organization.

* **Bug Fixes**
  * Improved modal rendering efficiency by ensuring the update modal only renders when needed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->