### PR TITLE
Fix Editor Sidebar Tab Rendering

### DIFF
--- a/apps/cms/src/components/editor/editor-sidebar.tsx
+++ b/apps/cms/src/components/editor/editor-sidebar.tsx
@@ -262,6 +262,7 @@ export function EditorSidebar({
           >
             <TabsContent
               className="min-h-0 flex-1 data-[state=inactive]:hidden"
+              forceMount
               value="metadata"
             >
               <Suspense fallback={<TabLoadingSpinner />}>
@@ -276,6 +277,7 @@ export function EditorSidebar({
 
             <TabsContent
               className="min-h-0 flex-1 data-[state=inactive]:hidden"
+              forceMount
               value="analysis"
             >
               <Suspense fallback={<TabLoadingSpinner />}>


### PR DESCRIPTION
## Description
Add `forceMount` prop to TabsContent components in EditorSidebar to ensure proper rendering of metadata and analysis tabs.

## Motivation and Context
Resolves rendering issues with editor sidebar tabs by ensuring they are always mounted, preventing potential display problems.

## How to Test
1. Open the CMS editor
2. Navigate between metadata and analysis tabs
3. Verify both tabs render correctly and switch smoothly

## Types of Changes
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

Closes #288 
  


 <br /> 


 > Want tembo to make any changes? Add a review or comment with `@tembo` and i'll get back to work! 


 [![tembo.io](https://internal.tembo.io/static/view/tembo.svg?v=4)](https://app.tembo.io/tasks/ead81366-b8c8-456f-8ee9-cce632ea3169)  [![app.tembo.io](https://internal.tembo.io/public/agent-button/claudeCode:claude-opus-4-5?v=1)](https://app.tembo.io/settings/agents)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed editor sidebar tabs to properly load and display content for metadata and analysis views even when inactive.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->