### PR TITLE
chore: add raycast extension to footer

### DIFF
--- a/apps/web/src/lib/constants/navigation.ts
+++ b/apps/web/src/lib/constants/navigation.ts
@@ -84,6 +84,13 @@ export const FOOTER_SECTIONS: FooterSection[] = [
         rel: "noopener",
       },
       {
+        label: "Raycast Extension",
+        href: "https://www.raycast.com/dominikdev/marble",
+        external: true,
+        target: "_blank",
+        rel: "noopener",
+      },
+      {
         label: "Astro Example",
         href: "https://github.com/usemarble/astro-example",
         external: true,


### PR DESCRIPTION
## Description

Adds the Raycast extension to the footer of the landing page!

## Motivation and Context

We link framer and other templates so why not Raycast too

## Types of Changes

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that alters existing functionality)
- [ ] 🎨 UI/UX Improvements
- [ ] ⚡ Performance Enhancement
- [x] 📖 Documentation (updates to README, docs, or comments)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Raycast Extension link to the Developers section in the footer navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->