### PR TITLE
fix: set cms turbopack root

### DIFF
--- a/apps/cms/next.config.ts
+++ b/apps/cms/next.config.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
@@ -11,6 +12,9 @@ const nextConfig: NextConfig = {
   reactCompiler: true,
   experimental: {
     optimizePackageImports: ["@phosphor-icons/react"],
+  },
+  turbopack: {
+    root: path.resolve(__dirname, "../.."),
   },
   async redirects() {
     return [


### PR DESCRIPTION
## Description

Sets the CMS Next.js Turbopack root to the monorepo root.

## Motivation and Context

This makes the Turbopack project root explicit for the CMS app so Next.js resolves the workspace from the repository root.

## How to Test

- Not run per request.

## Screenshots (if applicable)

N/A

## Video Demo (if applicable)

N/A

## Types of Changes

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that alters existing functionality)
- [ ] 🎨 UI/UX Improvements
- [ ] ⚡ Performance Enhancement
- [ ] 📖 Documentation (updates to README, docs, or comments)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CMS build configuration to include Turbopack settings pointing to the monorepo root directory. All existing Next.js configurations remain unchanged.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usemarble/marble/pull/340)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->