### PR TITLE
ci: use github-hosted runners

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 jobs:
   quality:
-    runs-on: tenki-standard-autoscale
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 jobs:
   tests:
-    runs-on: tenki-standard-autoscale
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
## Description

Updates the Tests and Code quality workflows to use GitHub-hosted `ubuntu-latest` runners instead of the Tenki autoscale runner.

## Motivation and Context

Tenki appears to cancel a lot of workflow runs. Using GitHub-hosted runners should make CI runs more reliable.

## How to Test

- Open this PR and confirm the Tests and Code quality workflows start on GitHub-hosted runners.

## Screenshots (if applicable)

N/A

## Video Demo (if applicable)

N/A

## Types of Changes

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that alters existing functionality)
- [ ] 🎨 UI/UX Improvements
- [ ] ⚡ Performance Enhancement
- [ ] 📖 Documentation (updates to README, docs, or comments)
