### PR TITLE
chore(web): update Neon sponsor logo

### DIFF
--- a/apps/web/src/components/icons/sponsors/Neon.astro
+++ b/apps/web/src/components/icons/sponsors/Neon.astro
@@ -6,64 +6,16 @@
 ---
 <svg
   xmlns="http://www.w3.org/2000/svg"
-  version="1.2"
-  viewBox="0 0 58 57"
+  width="64"
+  height="64"
+  viewBox="0 0 64 64"
+  fill="none"
   class={classNames}
   {...attrs}
 >
-  <title>Neon Logomark Color</title>
-  <defs>
-    <linearGradient
-      id="g1"
-      x2="1"
-      gradientUnits="userSpaceOnUse"
-      gradientTransform="matrix(-50.032,-57.652,62.466,-54.21,57.588,57)"
-    >
-      <stop offset="0" stop-color="#2ef51c" stop-opacity="1"/>
-      <stop offset="1" stop-color="#2ef51c" stop-opacity="0"/>
-    </linearGradient>
-    <linearGradient
-      id="g2"
-      x2="1"
-      gradientUnits="userSpaceOnUse"
-      gradientTransform="matrix(-34.011,-13.404,13.812,-35.046,57.461,56.966)"
-    >
-      <stop offset="0" stop-color="#000000" stop-opacity=".9"/>
-      <stop offset="1" stop-color="#1a1a1a" stop-opacity="0"/>
-    </linearGradient>
-  </defs>
-  <style>
-    .s0 {
-      fill: #32c0ed;
-    }
-    .s1 {
-      fill: url(#g1);
-    }
-    .s2 {
-      opacity: 0.3;
-      fill: url(#g2);
-    }
-    .s3 {
-      fill: #63f655;
-    }
-  </style>
+  <title>Neon logo</title>
   <path
-    fill-rule="evenodd"
-    class="s0"
-    d="m0 9.8c0-5.4 4.4-9.8 9.9-9.8h37.7c5.4 0 9.9 4.4 9.9 9.8v31.8c0 5.6-7.2 8-10.7 3.6l-10.8-13.9v16.9c0 4.8-4 8.8-9 8.8h-17.1c-5.5 0-9.9-4.4-9.9-9.8zm9.9-2c-1.1 0-2 0.9-2 2v37.3c0 1.1 0.9 2 2 2h17.4c0.6 0 0.7-0.5 0.7-1v-22.5c0-5.7 7.2-8.1 10.7-3.7l10.8 13.9v-26c0-1.1 0.1-2-1-2z"
-  />
-  <path
-    fill-rule="evenodd"
-    class="s1"
-    d="m0 9.8c0-5.4 4.4-9.8 9.9-9.8h37.7c5.4 0 9.9 4.4 9.9 9.8v31.8c0 5.6-7.2 8-10.7 3.6l-10.8-13.9v16.9c0 4.8-4 8.8-9 8.8h-17.1c-5.5 0-9.9-4.4-9.9-9.8zm9.9-2c-1.1 0-2 0.9-2 2v37.3c0 1.1 0.9 2 2 2h17.4c0.6 0 0.7-0.5 0.7-1v-22.5c0-5.7 7.2-8.1 10.7-3.7l10.8 13.9v-26c0-1.1 0.1-2-1-2z"
-  />
-  <path
-    fill-rule="evenodd"
-    class="s2"
-    d="m0 9.8c0-5.4 4.4-9.8 9.9-9.8h37.7c5.4 0 9.9 4.4 9.9 9.8v31.8c0 5.6-7.2 8-10.7 3.6l-10.8-13.9v16.9c0 4.8-4 8.8-9 8.8h-17.1c-5.5 0-9.9-4.4-9.9-9.8zm9.9-2c-1.1 0-2 0.9-2 2v37.3c0 1.1 0.9 2 2 2h17.4c0.6 0 0.7-0.5 0.7-1v-22.5c0-5.7 7.2-8.1 10.7-3.7l10.8 13.9v-26c0-1.1 0.1-2-1-2z"
-  />
-  <path
-    class="s3"
-    d="m47.6 0c5.4 0 9.9 4.4 9.9 9.8v31.8c0 5.6-7.2 8-10.7 3.6l-10.8-13.9v16.9c0 4.8-4 8.8-9 8.8 0.6 0 1-0.4 1-1v-30.4c0-5.6 7.2-8 10.7-3.6l10.8 13.9v-33.9c0-1.1-0.9-2-1.9-2z"
+    d="M63 0.0177909V63.5526L38.4178 42.2501V63.5526H0V0L63 0.0177909ZM7.72251 55.8389H30.6953V25.3238L55.2779 47.0476V7.72922L7.72251 7.71559V55.8389Z"
+    fill="#37C38F"
   />
 </svg>

--- a/apps/web/src/components/icons/sponsors/Neon.astro
+++ b/apps/web/src/components/icons/sponsors/Neon.astro
@@ -13,7 +13,7 @@
   class={classNames}
   {...attrs}
 >
-  <title>Neon logo</title>
+  <title>Neon Logo</title>
   <path
     d="M63 0.0177909V63.5526L38.4178 42.2501V63.5526H0V0L63 0.0177909ZM7.72251 55.8389H30.6953V25.3238L55.2779 47.0476V7.72922L7.72251 7.71559V55.8389Z"
     fill="#37C38F"


### PR DESCRIPTION
## Description

Replaces the Neon sponsor logo SVG in `apps/web/src/components/icons/sponsors/Neon.astro` with the updated single-path mark (green `#37C38F`, `viewBox="0 0 64 64"`). The existing Astro props pattern (`class={classNames} {...attrs}`) is preserved so all current usages keep their sizing/classes, and a `<title>Neon logo</title>` is included for accessibility.

## Motivation and Context

Brings the sponsor icon in line with Neon's current logo.

## How to Test

1. Run the web app and view any page rendering the Neon sponsor icon.
2. Confirm the new green mark displays correctly and inherits passed `class`/attributes (sizing, color context).
3. Verify the accessible title reads "Neon logo".

## Screenshots (if applicable)

<!--- Add screenshots to illustrate UI changes. -->

## Video Demo (if applicable)

<!--- Show screen recordings of the issue or feature. -->

## Types of Changes

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that alters existing functionality)
- [x] 🎨 UI/UX Improvements
- [ ] ⚡ Performance Enhancement
- [ ] 📖 Documentation (updates to README, docs, or comments)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the Neon sponsor logo with a simplified, modernized design for cleaner and more consistent appearance across the site.
* **Accessibility**
  * Improved logo labeling for clearer identification by assistive technologies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/usemarble/marble/pull/349?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->