### PR TITLE
feat: add editor-aware parser conversions

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -19,7 +19,6 @@
     "@upstash/redis": "^1.36.4",
     "hono": "^4.12.14",
     "image-size": "^2.0.2",
-    "node-html-markdown": "^2.0.0",
     "resend": "^6.12.3",
     "sanitize-html": "^2.17.1",
     "zod": "^4.3.6"

--- a/apps/api/src/routes/posts.ts
+++ b/apps/api/src/routes/posts.ts
@@ -1,7 +1,11 @@
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
 import { toPostPayload, withChanges } from "@marble/events";
-import { EMPTY_TIPTAP_DOC, htmlToTiptap } from "@marble/parser/tiptap";
-import { NodeHtmlMarkdown } from "node-html-markdown";
+import {
+  EMPTY_TIPTAP_DOC,
+  htmlToMarkdown,
+  htmlToTiptap,
+  normalizePostContent,
+} from "@marble/parser";
 import { cacheKey, createCacheClient, hashQueryParams } from "@/lib/cache";
 import { createDbClient } from "@/lib/db";
 import { emitEvent } from "@/lib/events";
@@ -325,7 +329,7 @@ posts.openapi(listPostsRoute, async (c) => {
       format === "markdown"
         ? postsData.map((post) => ({
             ...post,
-            content: NodeHtmlMarkdown.translate(post.content || ""),
+            content: htmlToMarkdown(post.content || ""),
           }))
         : postsData;
 
@@ -477,7 +481,7 @@ posts.openapi(getPostRoute, async (c) => {
       format === "markdown"
         ? {
             ...post,
-            content: NodeHtmlMarkdown.translate(post.content || ""),
+            content: htmlToMarkdown(post.content || ""),
           }
         : post;
 
@@ -643,7 +647,8 @@ posts.openapi(createPostRoute, async (c) => {
       : new Date();
 
     // 6. Create the post
-    const sanitizedContent = sanitizeHtml(body.content);
+    const normalizedContent = await normalizePostContent(body.content);
+    const sanitizedContent = sanitizeHtml(normalizedContent.html);
     let contentJson = EMPTY_TIPTAP_DOC;
 
     try {
@@ -939,7 +944,19 @@ posts.openapi(updatePostRoute, async (c) => {
       updateData.title = body.title;
     }
     if (body.content !== undefined) {
-      updateData.content = sanitizeHtml(body.content);
+      const normalizedContent = await normalizePostContent(body.content);
+      const sanitizedContent = sanitizeHtml(normalizedContent.html);
+      updateData.content = sanitizedContent;
+
+      try {
+        updateData.contentJson = htmlToTiptap(sanitizedContent);
+      } catch (error) {
+        console.error(
+          "[Posts] Failed to convert updated HTML to TipTap JSON:",
+          error
+        );
+        updateData.contentJson = EMPTY_TIPTAP_DOC;
+      }
     }
     if (body.description !== undefined) {
       updateData.description = body.description;

--- a/apps/cms/package.json
+++ b/apps/cms/package.json
@@ -49,7 +49,6 @@
     "nanoid": "^5.0.9",
     "next": "16.2.6",
     "next-themes": "^0.4.6",
-    "node-html-markdown": "^1.3.0",
     "nuqs": "^2.8.4",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/apps/cms/src/app/api/ai/suggestions/route.tsx
+++ b/apps/cms/src/app/api/ai/suggestions/route.tsx
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { db } from "@marble/db";
+import { htmlToMarkdown } from "@marble/parser";
 import { NextResponse } from "next/server";
-import { NodeHtmlMarkdown } from "node-html-markdown";
 import { requireActiveWorkspaceAccess } from "@/lib/auth/access";
 import { aiSuggestionsRateLimiter, rateLimitHeaders } from "@/lib/ratelimit";
 import { redis } from "@/lib/redis";
@@ -122,7 +122,7 @@ export async function POST(request: Request) {
         role: "user",
         content: `
         <CONTENT>
-        ${NodeHtmlMarkdown.translate(parsedBody.data.content)}
+        ${htmlToMarkdown(parsedBody.data.content)}
         </CONTENT>
         `,
       },

--- a/apps/cms/src/app/api/posts/import/route.ts
+++ b/apps/cms/src/app/api/posts/import/route.ts
@@ -1,6 +1,6 @@
 import { db } from "@marble/db";
 import { toPostPayload } from "@marble/events";
-import { markdownToHtml, markdownToTiptap } from "@marble/parser/tiptap";
+import { markdownToHtml, markdownToTiptap } from "@marble/parser";
 import { nanoid } from "nanoid";
 import { NextResponse } from "next/server";
 import { requireActiveWorkspaceAccess } from "@/lib/auth/access";

--- a/apps/cms/src/components/posts/import-modal.tsx
+++ b/apps/cms/src/components/posts/import-modal.tsx
@@ -15,7 +15,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import matter from "gray-matter";
 import { type Dispatch, type SetStateAction, useState } from "react";
 import { toast } from "sonner";
-import * as z from "zod";
+import { z } from "zod";
 import { Dropzone } from "@/components/shared/dropzone";
 import { useWorkspaceId } from "@/hooks/use-workspace-id";
 import { QUERY_KEYS } from "@/lib/queries/keys";

--- a/apps/cms/src/lib/validations/auth.ts
+++ b/apps/cms/src/lib/validations/auth.ts
@@ -1,4 +1,4 @@
-import * as z from "zod";
+import { z } from "zod";
 
 // auth form
 export const credentialSchema = z.object({

--- a/apps/cms/src/lib/validations/authors.ts
+++ b/apps/cms/src/lib/validations/authors.ts
@@ -1,4 +1,4 @@
-import * as z from "zod";
+import { z } from "zod";
 import { SOCIAL_PLATFORMS, type SocialPlatform } from "@/lib/constants";
 
 const socialLinkSchema = z.object({

--- a/apps/cms/src/lib/validations/editor.ts
+++ b/apps/cms/src/lib/validations/editor.ts
@@ -1,4 +1,4 @@
-import * as z from "zod";
+import { z } from "zod";
 
 export const aiReadabilityBodySchema = z.object({
   content: z.string(),

--- a/apps/cms/src/lib/validations/keys.ts
+++ b/apps/cms/src/lib/validations/keys.ts
@@ -1,4 +1,4 @@
-import * as z from "zod";
+import { z } from "zod";
 import { type ApiScope, VALID_SCOPES } from "@/utils/keys";
 
 export const apiKeyTypeEnum = z.enum(["public", "private"]);

--- a/apps/cms/src/lib/validations/settings.ts
+++ b/apps/cms/src/lib/validations/settings.ts
@@ -1,4 +1,4 @@
-import * as z from "zod";
+import { z } from "zod";
 
 export const profileSchema = z.object({
   name: z.string().min(1, { message: "Name cannot be blank" }),

--- a/apps/cms/src/lib/validations/workspace.ts
+++ b/apps/cms/src/lib/validations/workspace.ts
@@ -1,4 +1,4 @@
-import * as z from "zod";
+import { z } from "zod";
 import { RESERVED_WORKSPACE_SLUGS, timezones } from "@/lib/constants";
 
 const workspaceSlugField = z

--- a/packages/editor/src/components/marks/editor-link-selector.tsx
+++ b/packages/editor/src/components/marks/editor-link-selector.tsx
@@ -141,15 +141,7 @@ export const EditorLinkSelector = ({
         }
       />
       <PopoverContent align="start" className="w-fit p-0" sideOffset={10}>
-        <form
-          className="flex items-center gap-0.5 p-1"
-          onMouseDown={(e) => {
-            if (e.target !== inputReference.current) {
-              e.preventDefault();
-            }
-          }}
-          onSubmit={handleSubmit}
-        >
+        <form className="flex items-center gap-0.5 p-1" onSubmit={handleSubmit}>
           <input
             aria-label="Link URL"
             className="min-w-[200px] flex-1 bg-background px-2 py-1 text-sm outline-none"

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -2,7 +2,7 @@
   "name": "@marble/parser",
   "version": "0.0.0",
   "exports": {
-    "./tiptap": "./src/tiptap.ts"
+    ".": "./src/index.ts"
   },
   "scripts": {
     "test": "vitest run"

--- a/packages/parser/src/editor/extensions.ts
+++ b/packages/parser/src/editor/extensions.ts
@@ -1,0 +1,257 @@
+import {
+  type AnyExtension,
+  mergeAttributes,
+  Node as TiptapNode,
+} from "@tiptap/core";
+import { Highlight } from "@tiptap/extension-highlight";
+import { Image } from "@tiptap/extension-image";
+import { TaskItem, TaskList } from "@tiptap/extension-list";
+import { Subscript } from "@tiptap/extension-subscript";
+import { Superscript } from "@tiptap/extension-superscript";
+import {
+  Table,
+  TableCell,
+  TableHeader,
+  TableRow,
+} from "@tiptap/extension-table";
+import { TextAlign } from "@tiptap/extension-text-align";
+import { TextStyleKit } from "@tiptap/extension-text-style";
+import Typography from "@tiptap/extension-typography";
+import { Youtube } from "@tiptap/extension-youtube";
+import StarterKit from "@tiptap/starter-kit";
+import type { ParseableElement } from "./types";
+
+const queryHtml = (element: HTMLElement, selector: string) =>
+  (element as ParseableElement).querySelector(selector);
+
+/**
+ * Server-side version of Marble's editor figure node.
+ *
+ * The CMS editor renders this node through React, but API/parser code only
+ * needs a stable schema plus HTML parse/render behavior. Keeping it here lets
+ * `htmlToTiptap` preserve image captions, links, width, and alignment.
+ */
+const ServerFigure = TiptapNode.create({
+  name: "figure",
+  group: "block",
+  content: "",
+  draggable: true,
+  selectable: true,
+  isolating: true,
+
+  addAttributes() {
+    return {
+      src: {
+        default: null,
+        parseHTML: (element) =>
+          queryHtml(element, "img")?.getAttribute("src") ||
+          queryHtml(element, "a img")?.getAttribute("src"),
+        renderHTML: (attributes) => ({ src: attributes.src }),
+      },
+      alt: {
+        default: "",
+        parseHTML: (element) =>
+          queryHtml(element, "img")?.getAttribute("alt") ||
+          queryHtml(element, "a img")?.getAttribute("alt") ||
+          "",
+        renderHTML: (attributes) => ({ alt: attributes.alt }),
+      },
+      caption: {
+        default: "",
+        parseHTML: (element) =>
+          queryHtml(element, "figcaption")?.textContent || "",
+        renderHTML: (attributes) => ({ caption: attributes.caption }),
+      },
+      href: {
+        default: null,
+        parseHTML: (element) =>
+          queryHtml(element, "a")?.getAttribute("href") || null,
+        renderHTML: (attributes) => ({ href: attributes.href }),
+      },
+      width: {
+        default: "100",
+        parseHTML: (element) => element.getAttribute("data-width") || "100",
+        renderHTML: (attributes) => ({ "data-width": attributes.width }),
+      },
+      align: {
+        default: "center",
+        parseHTML: (element) => element.getAttribute("data-align") || "center",
+        renderHTML: (attributes) => ({ "data-align": attributes.align }),
+      },
+    };
+  },
+
+  parseHTML() {
+    return [
+      {
+        tag: "figure",
+        getAttrs: (element) => {
+          if (typeof element === "string") {
+            return false;
+          }
+          return queryHtml(element, "img") ? {} : false;
+        },
+      },
+    ];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    const { src, alt, href, caption, ...figureAttrs } = HTMLAttributes;
+    const imgAttrs: Record<string, string> = {};
+
+    if (src) {
+      imgAttrs.src = src;
+    }
+    if (alt) {
+      imgAttrs.alt = alt;
+    }
+
+    const image = href ? ["a", { href }, ["img", imgAttrs]] : ["img", imgAttrs];
+
+    return [
+      "figure",
+      mergeAttributes(figureAttrs),
+      image,
+      ["figcaption", {}, caption || ""],
+    ];
+  },
+});
+
+/**
+ * Server-side version of Marble's self-hosted video node.
+ */
+const ServerVideo = TiptapNode.create({
+  name: "video",
+  group: "block",
+  content: "",
+  draggable: true,
+  selectable: true,
+  isolating: true,
+
+  addAttributes() {
+    return {
+      src: {
+        default: null,
+        parseHTML: (element) =>
+          queryHtml(element, "video")?.getAttribute("src") ||
+          queryHtml(element, "video source")?.getAttribute("src") ||
+          element.getAttribute("src"),
+        renderHTML: (attributes) => ({ src: attributes.src }),
+      },
+      caption: {
+        default: "",
+        parseHTML: (element) =>
+          queryHtml(element, "figcaption")?.textContent || "",
+        renderHTML: (attributes) => ({ caption: attributes.caption }),
+      },
+      width: {
+        default: "100",
+        parseHTML: (element) => element.getAttribute("data-width") || "100",
+        renderHTML: (attributes) => ({ "data-width": attributes.width }),
+      },
+      align: {
+        default: "center",
+        parseHTML: (element) => element.getAttribute("data-align") || "center",
+        renderHTML: (attributes) => ({ "data-align": attributes.align }),
+      },
+    };
+  },
+
+  parseHTML() {
+    return [
+      {
+        tag: "figure",
+        getAttrs: (element) => {
+          if (typeof element === "string") {
+            return false;
+          }
+          return queryHtml(element, "video") ? {} : false;
+        },
+      },
+      { tag: "video" },
+    ];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    const { src, caption, ...figureAttrs } = HTMLAttributes;
+    const videoAttrs: Record<string, string> = { controls: "true" };
+
+    if (src) {
+      videoAttrs.src = src;
+    }
+
+    return [
+      "figure",
+      mergeAttributes({ "data-type": "video" }, figureAttrs),
+      ["video", videoAttrs],
+      ["figcaption", {}, caption || ""],
+    ];
+  },
+});
+
+/**
+ * Server-side version of Marble's X/Twitter embed node.
+ */
+const ServerTwitter = TiptapNode.create({
+  name: "twitter",
+  group: "block",
+  draggable: true,
+
+  addAttributes() {
+    return {
+      src: {
+        default: null,
+        parseHTML: (element) => element.getAttribute("data-src"),
+        renderHTML: (attributes) =>
+          attributes.src ? { "data-src": attributes.src } : {},
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: "div[data-twitter]" }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ["div", mergeAttributes({ "data-twitter": "" }, HTMLAttributes)];
+  },
+});
+
+/**
+ * Extensions used by server-side parser code. This mirrors the editor's schema
+ * closely enough for API conversions without importing React node views.
+ */
+export const htmlExtensions: AnyExtension[] = [
+  StarterKit.configure({
+    link: {
+      openOnClick: false,
+    },
+  }),
+  Typography,
+  Highlight,
+  TextStyleKit,
+  TextAlign.configure({
+    types: ["heading", "paragraph"],
+  }),
+  Superscript,
+  Subscript,
+  Table,
+  TableRow,
+  TableCell,
+  TableHeader,
+  Youtube.configure({
+    controls: true,
+    nocookie: false,
+  }),
+  Image.configure({
+    inline: false,
+    allowBase64: false,
+  }),
+  ServerFigure,
+  ServerVideo,
+  ServerTwitter,
+  TaskList,
+  TaskItem.configure({
+    nested: true,
+  }),
+];

--- a/packages/parser/src/editor/html.ts
+++ b/packages/parser/src/editor/html.ts
@@ -1,0 +1,264 @@
+import { getSchema, type JSONContent } from "@tiptap/core";
+import { parseHTML } from "linkedom";
+import { DOMParser as PMDOMParser } from "prosemirror-model";
+import { htmlExtensions } from "./extensions";
+import { EMPTY_TIPTAP_DOC } from "./types";
+
+type MarkdownElement = HTMLElement & {
+  childNodes: NodeListOf<ChildNode>;
+  getAttribute: (name: string) => string | null;
+  hasAttribute: (name: string) => boolean;
+  querySelector: (selector: string) => MarkdownElement | null;
+  querySelectorAll: (selector: string) => NodeListOf<MarkdownElement>;
+};
+
+const blockNodes = new Set([
+  "ADDRESS",
+  "ARTICLE",
+  "ASIDE",
+  "BLOCKQUOTE",
+  "DIV",
+  "DL",
+  "FIGURE",
+  "FOOTER",
+  "FORM",
+  "H1",
+  "H2",
+  "H3",
+  "H4",
+  "H5",
+  "H6",
+  "HEADER",
+  "HR",
+  "LI",
+  "MAIN",
+  "NAV",
+  "OL",
+  "P",
+  "PRE",
+  "SECTION",
+  "TABLE",
+  "UL",
+]);
+
+const escapeMarkdown = (value: string) =>
+  value
+    .replace(/\\/g, "\\\\")
+    .replace(/\*/g, "\\*")
+    .replace(/_/g, "\\_")
+    .replace(/`/g, "\\`")
+    .replace(/\[/g, "\\[")
+    .replace(/]/g, "\\]");
+
+const normalizeWhitespace = (value: string) => value.replace(/\s+/g, " ");
+
+const isElement = (node: ChildNode): node is MarkdownElement =>
+  node.nodeType === 1;
+
+const isText = (node: ChildNode) => node.nodeType === 3;
+
+const childrenToMarkdown = (element: MarkdownElement) =>
+  Array.from(element.childNodes)
+    .map((child) => nodeToMarkdown(child))
+    .join("");
+
+const block = (value: string) => {
+  const trimmed = value.trim();
+  return trimmed ? `${trimmed}\n\n` : "";
+};
+
+const rawHtmlBlock = (element: MarkdownElement) => block(element.outerHTML);
+
+const imageMarkdown = (image: MarkdownElement) => {
+  const src = image.getAttribute("src");
+  const alt = image.getAttribute("alt") || "";
+
+  if (!src) {
+    return "";
+  }
+
+  return `![${escapeMarkdown(alt)}](${src})`;
+};
+
+const tableCellText = (cell: MarkdownElement) =>
+  normalizeWhitespace(childrenToMarkdown(cell)).replace(/\|/g, "\\|").trim();
+
+const tableToMarkdown = (table: MarkdownElement) => {
+  const rows = Array.from(
+    table.querySelectorAll("tr") as unknown as MarkdownElement[]
+  );
+
+  if (rows.length === 0) {
+    return "";
+  }
+
+  const serializedRows = rows.map((row) =>
+    Array.from(
+      row.querySelectorAll("th,td") as unknown as MarkdownElement[]
+    ).map(tableCellText)
+  );
+  const maxCells = Math.max(...serializedRows.map((row) => row.length));
+  const header = serializedRows[0] || [];
+  const normalizedHeader = Array.from(
+    { length: maxCells },
+    (_, index) => header[index] || ""
+  );
+  const separator = Array.from({ length: maxCells }, () => "---");
+  const bodyRows = serializedRows.slice(1);
+  const rowToMarkdown = (row: string[]) =>
+    `| ${Array.from({ length: maxCells }, (_, index) => row[index] || "").join(" | ")} |`;
+
+  return block(
+    [rowToMarkdown(normalizedHeader), rowToMarkdown(separator)]
+      .concat(bodyRows.map(rowToMarkdown))
+      .join("\n")
+  );
+};
+
+const listToMarkdown = (list: MarkdownElement, ordered: boolean) => {
+  const items = Array.from(list.childNodes).filter(
+    (child): child is MarkdownElement =>
+      isElement(child) && child.nodeName === "LI"
+  );
+
+  return block(
+    items
+      .map((item, index) => {
+        const checkbox = item.querySelector('input[type="checkbox"]');
+        const marker = ordered ? `${index + 1}.` : "-";
+        const taskMarker = checkbox
+          ? `[${checkbox.hasAttribute("checked") ? "x" : " "}] `
+          : "";
+        const text = normalizeWhitespace(childrenToMarkdown(item)).trim();
+        return `${marker} ${taskMarker}${text}`;
+      })
+      .join("\n")
+  );
+};
+
+const nodeToMarkdown = (node: ChildNode): string => {
+  if (isText(node)) {
+    const text = node.textContent || "";
+    return /^\s+$/.test(text) ? "" : escapeMarkdown(normalizeWhitespace(text));
+  }
+
+  if (!isElement(node)) {
+    return "";
+  }
+
+  switch (node.nodeName) {
+    case "H1":
+    case "H2":
+    case "H3":
+    case "H4":
+    case "H5":
+    case "H6": {
+      const level = Number(node.nodeName.slice(1));
+      return block(`${"#".repeat(level)} ${childrenToMarkdown(node).trim()}`);
+    }
+    case "P":
+      return block(childrenToMarkdown(node));
+    case "STRONG":
+    case "B":
+      return `**${childrenToMarkdown(node).trim()}**`;
+    case "EM":
+    case "I":
+      return `*${childrenToMarkdown(node).trim()}*`;
+    case "S":
+    case "DEL":
+      return `~~${childrenToMarkdown(node).trim()}~~`;
+    case "CODE":
+      if (node.parentElement?.nodeName === "PRE") {
+        return node.textContent || "";
+      }
+      return `\`${node.textContent || ""}\``;
+    case "PRE": {
+      const code = node.querySelector("code");
+      const languageClass = code?.getAttribute("class") || "";
+      const language = languageClass.replace(/^language-/, "");
+      const codeText = (code?.textContent || node.textContent || "").replace(
+        /\n+$/,
+        ""
+      );
+      return block(`\`\`\`${language}\n${codeText}\n\`\`\``);
+    }
+    case "A": {
+      const href = node.getAttribute("href");
+      const text = childrenToMarkdown(node).trim();
+      return href ? `[${text}](${href})` : text;
+    }
+    case "IMG":
+      return imageMarkdown(node);
+    case "BR":
+      return "\n";
+    case "HR":
+      return "---\n\n";
+    case "BLOCKQUOTE":
+      return block(
+        childrenToMarkdown(node)
+          .trim()
+          .split("\n")
+          .map((line) => `> ${line}`)
+          .join("\n")
+      );
+    case "UL":
+      return listToMarkdown(node, false);
+    case "OL":
+      return listToMarkdown(node, true);
+    case "TABLE":
+      return tableToMarkdown(node);
+    case "FIGURE":
+      return rawHtmlBlock(node);
+    case "DIV":
+      if (
+        node.hasAttribute("data-youtube-video") ||
+        node.hasAttribute("data-twitter")
+      ) {
+        return rawHtmlBlock(node);
+      }
+      return block(childrenToMarkdown(node));
+    default: {
+      const content = childrenToMarkdown(node);
+      return blockNodes.has(node.nodeName) ? block(content) : content;
+    }
+  }
+};
+
+/**
+ * Converts sanitized editor HTML into Tiptap JSON using Marble's server-side
+ * schema. Custom editor nodes such as figures, videos, Twitter embeds, and
+ * YouTube iframes are preserved when their HTML matches the extension rules.
+ */
+export function htmlToTiptap(html: string): JSONContent {
+  if (!html.trim()) {
+    return EMPTY_TIPTAP_DOC;
+  }
+
+  const schema = getSchema(htmlExtensions);
+  const { document } = parseHTML(
+    `<!doctype html><html><body>${html}</body></html>`
+  );
+
+  return PMDOMParser.fromSchema(schema)
+    .parse(document.body as unknown as Node)
+    .toJSON();
+}
+
+/**
+ * Converts editor HTML to Markdown while preserving Marble-specific embeds as
+ * raw HTML when Markdown has no faithful representation.
+ */
+export function htmlToMarkdown(html: string): string {
+  if (!html.trim()) {
+    return "";
+  }
+
+  const { document } = parseHTML(
+    `<!doctype html><html><body>${html}</body></html>`
+  );
+
+  return Array.from(document.body.childNodes)
+    .map((child) => nodeToMarkdown(child))
+    .join("")
+    .trim();
+}

--- a/packages/parser/src/editor/html.ts
+++ b/packages/parser/src/editor/html.ts
@@ -1,0 +1,287 @@
+import { getSchema, type JSONContent } from "@tiptap/core";
+import { parseHTML } from "linkedom";
+import { DOMParser as PMDOMParser } from "prosemirror-model";
+import { htmlExtensions } from "./extensions";
+import { EMPTY_TIPTAP_DOC } from "./types";
+
+type MarkdownElement = HTMLElement & {
+  childNodes: NodeListOf<ChildNode>;
+  getAttribute: (name: string) => string | null;
+  hasAttribute: (name: string) => boolean;
+  querySelector: (selector: string) => MarkdownElement | null;
+  querySelectorAll: (selector: string) => NodeListOf<MarkdownElement>;
+};
+
+const blockNodes = new Set([
+  "ADDRESS",
+  "ARTICLE",
+  "ASIDE",
+  "BLOCKQUOTE",
+  "DIV",
+  "DL",
+  "FIGURE",
+  "FOOTER",
+  "FORM",
+  "H1",
+  "H2",
+  "H3",
+  "H4",
+  "H5",
+  "H6",
+  "HEADER",
+  "HR",
+  "LI",
+  "MAIN",
+  "NAV",
+  "OL",
+  "P",
+  "PRE",
+  "SECTION",
+  "TABLE",
+  "UL",
+]);
+
+const escapeMarkdown = (value: string) =>
+  value
+    .replace(/\\/g, "\\\\")
+    .replace(/\*/g, "\\*")
+    .replace(/_/g, "\\_")
+    .replace(/`/g, "\\`")
+    .replace(/\[/g, "\\[")
+    .replace(/]/g, "\\]");
+
+const normalizeWhitespace = (value: string) => value.replace(/\s+/g, " ");
+
+const isElement = (node: ChildNode): node is MarkdownElement =>
+  node.nodeType === 1;
+
+const isText = (node: ChildNode) => node.nodeType === 3;
+
+const childrenToMarkdown = (element: MarkdownElement) =>
+  Array.from(element.childNodes)
+    .map((child) => nodeToMarkdown(child))
+    .join("");
+
+const block = (value: string) => {
+  const trimmed = value.trim();
+  return trimmed ? `${trimmed}\n\n` : "";
+};
+
+const rawHtmlBlock = (element: MarkdownElement) => block(element.outerHTML);
+
+const imageMarkdown = (image: MarkdownElement) => {
+  const src = image.getAttribute("src");
+  const alt = image.getAttribute("alt") || "";
+
+  if (!src) {
+    return "";
+  }
+
+  return `![${escapeMarkdown(alt)}](${src})`;
+};
+
+const tableCellText = (cell: MarkdownElement) =>
+  normalizeWhitespace(childrenToMarkdown(cell)).replace(/\|/g, "\\|").trim();
+
+const tableToMarkdown = (table: MarkdownElement) => {
+  const rows = Array.from(
+    table.querySelectorAll("tr") as unknown as MarkdownElement[]
+  );
+
+  if (rows.length === 0) {
+    return "";
+  }
+
+  const serializedRows = rows.map((row) =>
+    Array.from(
+      row.querySelectorAll("th,td") as unknown as MarkdownElement[]
+    ).map(tableCellText)
+  );
+  const maxCells = Math.max(...serializedRows.map((row) => row.length));
+  const header = serializedRows[0] || [];
+  const normalizedHeader = Array.from(
+    { length: maxCells },
+    (_, index) => header[index] || ""
+  );
+  const separator = Array.from({ length: maxCells }, () => "---");
+  const bodyRows = serializedRows.slice(1);
+  const rowToMarkdown = (row: string[]) =>
+    `| ${Array.from({ length: maxCells }, (_, index) => row[index] || "").join(" | ")} |`;
+
+  return block(
+    [rowToMarkdown(normalizedHeader), rowToMarkdown(separator)]
+      .concat(bodyRows.map(rowToMarkdown))
+      .join("\n")
+  );
+};
+
+const listToMarkdown = (list: MarkdownElement, ordered: boolean) => {
+  const items = Array.from(list.childNodes).filter(
+    (child): child is MarkdownElement =>
+      isElement(child) && child.nodeName === "LI"
+  );
+
+  return block(
+    items
+      .map((item, index) => {
+        const checkbox = item.querySelector('input[type="checkbox"]');
+        const marker = ordered ? `${index + 1}.` : "-";
+        const taskMarker = checkbox
+          ? `[${checkbox.hasAttribute("checked") ? "x" : " "}] `
+          : "";
+        const inlineParts: string[] = [];
+        const nestedParts: string[] = [];
+
+        for (const child of Array.from(item.childNodes)) {
+          if (
+            isElement(child) &&
+            (child.nodeName === "UL" || child.nodeName === "OL")
+          ) {
+            const nested = listToMarkdown(child, child.nodeName === "OL")
+              .trimEnd()
+              .split("\n")
+              .map((line) => (line ? `  ${line}` : line))
+              .join("\n");
+
+            if (nested) {
+              nestedParts.push(nested);
+            }
+            continue;
+          }
+
+          inlineParts.push(nodeToMarkdown(child));
+        }
+
+        const text = normalizeWhitespace(inlineParts.join("")).trim();
+        return `${marker} ${taskMarker}${text}${nestedParts.length ? `\n${nestedParts.join("\n")}` : ""}`;
+      })
+      .join("\n")
+  );
+};
+
+const nodeToMarkdown = (node: ChildNode): string => {
+  if (isText(node)) {
+    const text = node.textContent || "";
+    return /^\s+$/.test(text) ? "" : escapeMarkdown(normalizeWhitespace(text));
+  }
+
+  if (!isElement(node)) {
+    return "";
+  }
+
+  switch (node.nodeName) {
+    case "H1":
+    case "H2":
+    case "H3":
+    case "H4":
+    case "H5":
+    case "H6": {
+      const level = Number(node.nodeName.slice(1));
+      return block(`${"#".repeat(level)} ${childrenToMarkdown(node).trim()}`);
+    }
+    case "P":
+      return block(childrenToMarkdown(node));
+    case "STRONG":
+    case "B":
+      return `**${childrenToMarkdown(node).trim()}**`;
+    case "EM":
+    case "I":
+      return `*${childrenToMarkdown(node).trim()}*`;
+    case "S":
+    case "DEL":
+      return `~~${childrenToMarkdown(node).trim()}~~`;
+    case "CODE":
+      if (node.parentElement?.nodeName === "PRE") {
+        return node.textContent || "";
+      }
+      return `\`${node.textContent || ""}\``;
+    case "PRE": {
+      const code = node.querySelector("code");
+      const languageClass = code?.getAttribute("class") || "";
+      const language = languageClass.replace(/^language-/, "");
+      const codeText = (code?.textContent || node.textContent || "").replace(
+        /\n+$/,
+        ""
+      );
+      return block(`\`\`\`${language}\n${codeText}\n\`\`\``);
+    }
+    case "A": {
+      const href = node.getAttribute("href");
+      const text = childrenToMarkdown(node).trim();
+      return href ? `[${text}](${href})` : text;
+    }
+    case "IMG":
+      return imageMarkdown(node);
+    case "BR":
+      return "\n";
+    case "HR":
+      return "---\n\n";
+    case "BLOCKQUOTE":
+      return block(
+        childrenToMarkdown(node)
+          .trim()
+          .split("\n")
+          .map((line) => `> ${line}`)
+          .join("\n")
+      );
+    case "UL":
+      return listToMarkdown(node, false);
+    case "OL":
+      return listToMarkdown(node, true);
+    case "TABLE":
+      return tableToMarkdown(node);
+    case "FIGURE":
+      return rawHtmlBlock(node);
+    case "DIV":
+      if (
+        node.hasAttribute("data-youtube-video") ||
+        node.hasAttribute("data-twitter")
+      ) {
+        return rawHtmlBlock(node);
+      }
+      return block(childrenToMarkdown(node));
+    default: {
+      const content = childrenToMarkdown(node);
+      return blockNodes.has(node.nodeName) ? block(content) : content;
+    }
+  }
+};
+
+/**
+ * Converts sanitized editor HTML into Tiptap JSON using Marble's server-side
+ * schema. Custom editor nodes such as figures, videos, Twitter embeds, and
+ * YouTube iframes are preserved when their HTML matches the extension rules.
+ */
+export function htmlToTiptap(html: string): JSONContent {
+  if (!html.trim()) {
+    return EMPTY_TIPTAP_DOC;
+  }
+
+  const schema = getSchema(htmlExtensions);
+  const { document } = parseHTML(
+    `<!doctype html><html><body>${html}</body></html>`
+  );
+
+  return PMDOMParser.fromSchema(schema)
+    .parse(document.body as unknown as Node)
+    .toJSON();
+}
+
+/**
+ * Converts editor HTML to Markdown while preserving Marble-specific embeds as
+ * raw HTML when Markdown has no faithful representation.
+ */
+export function htmlToMarkdown(html: string): string {
+  if (!html.trim()) {
+    return "";
+  }
+
+  const { document } = parseHTML(
+    `<!doctype html><html><body>${html}</body></html>`
+  );
+
+  return Array.from(document.body.childNodes)
+    .map((child) => nodeToMarkdown(child))
+    .join("")
+    .trim();
+}

--- a/packages/parser/src/editor/markdown.ts
+++ b/packages/parser/src/editor/markdown.ts
@@ -1,269 +1,13 @@
-import {
-  getSchema,
-  type JSONContent,
-  mergeAttributes,
-  Node as TiptapNode,
-} from "@tiptap/core";
-import { Highlight } from "@tiptap/extension-highlight";
-import { Image } from "@tiptap/extension-image";
-import { TaskItem, TaskList } from "@tiptap/extension-list";
-import { Subscript } from "@tiptap/extension-subscript";
-import { Superscript } from "@tiptap/extension-superscript";
-import {
-  Table,
-  TableCell,
-  TableHeader,
-  TableRow,
-} from "@tiptap/extension-table";
-import { TextAlign } from "@tiptap/extension-text-align";
-import { TextStyleKit } from "@tiptap/extension-text-style";
-import Typography from "@tiptap/extension-typography";
-import { Youtube } from "@tiptap/extension-youtube";
-import StarterKit from "@tiptap/starter-kit";
-import { parseHTML } from "linkedom";
+import type { JSONContent } from "@tiptap/core";
 import { marked, type Token, type Tokens } from "marked";
-import { DOMParser as PMDOMParser } from "prosemirror-model";
 
-export const EMPTY_TIPTAP_DOC: JSONContent = { type: "doc", content: [] };
-
-type ParseableElement = HTMLElement & {
-  querySelector: (selector: string) => ParseableElement | null;
-  textContent: string | null;
-};
-
-const queryHtml = (element: HTMLElement, selector: string) =>
-  (element as ParseableElement).querySelector(selector);
-
-const ServerFigure = TiptapNode.create({
-  name: "figure",
-  group: "block",
-  content: "",
-  draggable: true,
-  selectable: true,
-  isolating: true,
-
-  addAttributes() {
-    return {
-      src: {
-        default: null,
-        parseHTML: (element) =>
-          queryHtml(element, "img")?.getAttribute("src") ||
-          queryHtml(element, "a img")?.getAttribute("src"),
-        renderHTML: (attributes) => ({ src: attributes.src }),
-      },
-      alt: {
-        default: "",
-        parseHTML: (element) =>
-          queryHtml(element, "img")?.getAttribute("alt") ||
-          queryHtml(element, "a img")?.getAttribute("alt") ||
-          "",
-        renderHTML: (attributes) => ({ alt: attributes.alt }),
-      },
-      caption: {
-        default: "",
-        parseHTML: (element) =>
-          queryHtml(element, "figcaption")?.textContent || "",
-        renderHTML: (attributes) => ({ caption: attributes.caption }),
-      },
-      href: {
-        default: null,
-        parseHTML: (element) =>
-          queryHtml(element, "a")?.getAttribute("href") || null,
-        renderHTML: (attributes) => ({ href: attributes.href }),
-      },
-      width: {
-        default: "100",
-        parseHTML: (element) => element.getAttribute("data-width") || "100",
-        renderHTML: (attributes) => ({ "data-width": attributes.width }),
-      },
-      align: {
-        default: "center",
-        parseHTML: (element) => element.getAttribute("data-align") || "center",
-        renderHTML: (attributes) => ({ "data-align": attributes.align }),
-      },
-    };
-  },
-
-  parseHTML() {
-    return [
-      {
-        tag: "figure",
-        getAttrs: (element) => {
-          if (typeof element === "string") {
-            return false;
-          }
-          return queryHtml(element, "img") ? {} : false;
-        },
-      },
-    ];
-  },
-
-  renderHTML({ HTMLAttributes }) {
-    const { src, alt, href, caption, ...figureAttrs } = HTMLAttributes;
-    const imgAttrs: Record<string, string> = {};
-
-    if (src) {
-      imgAttrs.src = src;
-    }
-    if (alt) {
-      imgAttrs.alt = alt;
-    }
-
-    const image = href ? ["a", { href }, ["img", imgAttrs]] : ["img", imgAttrs];
-
-    return [
-      "figure",
-      mergeAttributes(figureAttrs),
-      image,
-      ["figcaption", {}, caption || ""],
-    ];
-  },
-});
-
-const ServerVideo = TiptapNode.create({
-  name: "video",
-  group: "block",
-  content: "",
-  draggable: true,
-  selectable: true,
-  isolating: true,
-
-  addAttributes() {
-    return {
-      src: {
-        default: null,
-        parseHTML: (element) =>
-          queryHtml(element, "video")?.getAttribute("src") ||
-          queryHtml(element, "video source")?.getAttribute("src") ||
-          element.getAttribute("src"),
-        renderHTML: (attributes) => ({ src: attributes.src }),
-      },
-      caption: {
-        default: "",
-        parseHTML: (element) =>
-          queryHtml(element, "figcaption")?.textContent || "",
-        renderHTML: (attributes) => ({ caption: attributes.caption }),
-      },
-      width: {
-        default: "100",
-        parseHTML: (element) => element.getAttribute("data-width") || "100",
-        renderHTML: (attributes) => ({ "data-width": attributes.width }),
-      },
-      align: {
-        default: "center",
-        parseHTML: (element) => element.getAttribute("data-align") || "center",
-        renderHTML: (attributes) => ({ "data-align": attributes.align }),
-      },
-    };
-  },
-
-  parseHTML() {
-    return [
-      {
-        tag: "figure",
-        getAttrs: (element) => {
-          if (typeof element === "string") {
-            return false;
-          }
-          return queryHtml(element, "video") ? {} : false;
-        },
-      },
-      { tag: "video" },
-    ];
-  },
-
-  renderHTML({ HTMLAttributes }) {
-    const { src, caption, ...figureAttrs } = HTMLAttributes;
-    const videoAttrs: Record<string, string> = { controls: "true" };
-
-    if (src) {
-      videoAttrs.src = src;
-    }
-
-    return [
-      "figure",
-      mergeAttributes({ "data-type": "video" }, figureAttrs),
-      ["video", videoAttrs],
-      ["figcaption", {}, caption || ""],
-    ];
-  },
-});
-
-const ServerTwitter = TiptapNode.create({
-  name: "twitter",
-  group: "block",
-  draggable: true,
-
-  addAttributes() {
-    return {
-      src: {
-        default: null,
-        parseHTML: (element) => element.getAttribute("data-src"),
-        renderHTML: (attributes) =>
-          attributes.src ? { "data-src": attributes.src } : {},
-      },
-    };
-  },
-
-  parseHTML() {
-    return [{ tag: "div[data-twitter]" }];
-  },
-
-  renderHTML({ HTMLAttributes }) {
-    return ["div", mergeAttributes({ "data-twitter": "" }, HTMLAttributes)];
-  },
-});
-
-const htmlExtensions = [
-  StarterKit.configure({
-    link: {
-      openOnClick: false,
-    },
-  }),
-  Typography,
-  Highlight,
-  TextStyleKit,
-  TextAlign.configure({
-    types: ["heading", "paragraph"],
-  }),
-  Superscript,
-  Subscript,
-  Table,
-  TableRow,
-  TableCell,
-  TableHeader,
-  Youtube.configure({
-    controls: true,
-    nocookie: false,
-  }),
-  Image.configure({
-    inline: false,
-    allowBase64: false,
-  }),
-  ServerFigure,
-  ServerVideo,
-  ServerTwitter,
-  TaskList,
-  TaskItem.configure({
-    nested: true,
-  }),
-];
-
-export function htmlToTiptap(html: string): JSONContent {
-  if (!html.trim()) {
-    return EMPTY_TIPTAP_DOC;
-  }
-
-  const schema = getSchema(htmlExtensions);
-  const { document } = parseHTML(
-    `<!doctype html><html><body>${html}</body></html>`
-  );
-
-  return PMDOMParser.fromSchema(schema)
-    .parse(document.body as unknown as Node)
-    .toJSON();
-}
-
+/**
+ * Converts Markdown tokens into Tiptap JSON for the CMS import flow.
+ *
+ * This parser intentionally mirrors the existing import behavior instead of
+ * claiming full CommonMark fidelity. Rich Marble-only nodes should be handled
+ * through HTML parsing or future editor-aware Markdown rules.
+ */
 export class MarkdownToTiptapParser {
   private tokens: Token[] = [];
 
@@ -386,9 +130,6 @@ export class MarkdownToTiptapParser {
     const parser = new MarkdownToTiptapParser();
     let content = parser.parseTokens(item.tokens || []);
 
-    // In tight lists, marked doesn't wrap content in paragraphs
-    // If the content is empty but we have text, or if content exists without paragraph wrapping
-    // Check if we need to wrap in a paragraph
     if (
       content.length > 0 &&
       content.every(
@@ -398,17 +139,14 @@ export class MarkdownToTiptapParser {
           node.type !== "blockquote"
       )
     ) {
-      // Content exists but isn't block-level, wrap it in a paragraph
       content = [{ type: "paragraph", content }];
     } else if (content.length === 0 && item.text) {
-      // Fallback: parse the text as markdown if tokens are empty
       const textTokens = marked.lexer(item.text);
       content = parser.parseTokens(textTokens);
       if (
         content.length === 0 ||
         content.every((node) => node.type !== "paragraph")
       ) {
-        // Still no paragraph, create one from the raw text
         content = [
           { type: "paragraph", content: [{ type: "text", text: item.text }] },
         ];
@@ -594,11 +332,18 @@ export class MarkdownToTiptapParser {
   }
 }
 
+/**
+ * Converts Markdown into Tiptap JSON for the post import endpoint.
+ */
 export function markdownToTiptap(markdown: string): JSONContent {
   const parser = new MarkdownToTiptapParser();
   return parser.parse(markdown);
 }
 
+/**
+ * Converts Markdown to HTML using the same GFM/breaks settings as the import
+ * JSON parser. The result should still be sanitized before storage.
+ */
 export async function markdownToHtml(markdown: string): Promise<string> {
   marked.setOptions({ gfm: true, breaks: true });
   return await marked(markdown);

--- a/packages/parser/src/editor/normalize.ts
+++ b/packages/parser/src/editor/normalize.ts
@@ -1,0 +1,90 @@
+import type { JSONContent } from "@tiptap/core";
+import { htmlToTiptap } from "./html";
+import { markdownToHtml } from "./markdown";
+
+export type PostContentFormat = "html" | "markdown";
+
+export interface NormalizedPostContent {
+  /**
+   * Sanitizer-ready HTML derived from the input. Callers should still sanitize
+   * this value before storage because parser conversion is not an HTML policy.
+   */
+  html: string;
+  /**
+   * Tiptap JSON generated from the same source content.
+   */
+  contentJson: JSONContent;
+  /**
+   * Best-effort format classification used to choose the conversion path.
+   */
+  detectedFormat: PostContentFormat;
+}
+
+const htmlTagPattern = /<\/?[a-z][\s\S]*>/i;
+
+const markdownPatterns = [
+  /^#{1,6}\s+.+/m,
+  /\*\*[^*]+\*\*/m,
+  /__[^_]+__/m,
+  /\*[^*\n]+\*/m,
+  /_[^_\n]+_/m,
+  /\[[^\]]+\]\([^)]+\)/m,
+  /^\s*[-*+]\s+\S+/m,
+  /^\s*\d+\.\s+\S+/m,
+  /```[\s\S]*?```/m,
+  /`[^`\n]+`/m,
+  /^\s*>\s+\S+/m,
+  /!\[[^\]]*]\([^)]+\)/m,
+  /^\s*[-*_]{3,}\s*$/m,
+  /^\|.+\|$/m,
+];
+
+const headingPattern = /^#{1,6}\s+.+/m;
+
+/**
+ * Classifies post content as HTML or Markdown for defensive conversion.
+ *
+ * This intentionally biases toward HTML whenever real tags are present. Marble
+ * stores post content as HTML, so ambiguous input should stay on the official
+ * write path instead of being reinterpreted as Markdown.
+ */
+export function detectPostContentFormat(content: string): PostContentFormat {
+  const trimmed = content.trim();
+
+  if (!trimmed) {
+    return "html";
+  }
+
+  const matchCount = markdownPatterns.filter((pattern) =>
+    pattern.test(trimmed)
+  ).length;
+  const hasStrongMarkdownSignal =
+    matchCount >= 2 || headingPattern.test(trimmed);
+
+  if (htmlTagPattern.test(trimmed) && !hasStrongMarkdownSignal) {
+    return "html";
+  }
+
+  return hasStrongMarkdownSignal ? "markdown" : "html";
+}
+
+/**
+ * Converts post content into Marble's storage pair: HTML plus Tiptap JSON.
+ *
+ * The JSON is derived from the generated/supplied HTML so raw editor HTML
+ * embedded inside Markdown, such as figures and embeds, follows the same custom
+ * node parsing path as normal HTML writes.
+ */
+export async function normalizePostContent(
+  content: string
+): Promise<NormalizedPostContent> {
+  const detectedFormat = detectPostContentFormat(content);
+  const html =
+    detectedFormat === "markdown" ? await markdownToHtml(content) : content;
+
+  return {
+    html,
+    contentJson: htmlToTiptap(html),
+    detectedFormat,
+  };
+}

--- a/packages/parser/src/editor/normalize.ts
+++ b/packages/parser/src/editor/normalize.ts
@@ -1,0 +1,90 @@
+import type { JSONContent } from "@tiptap/core";
+import { htmlToTiptap } from "./html";
+import { markdownToHtml } from "./markdown";
+
+export type PostContentFormat = "html" | "markdown";
+
+export interface NormalizedPostContent {
+  /**
+   * Sanitizer-ready HTML derived from the input. Callers should still sanitize
+   * this value before storage because parser conversion is not an HTML policy.
+   */
+  html: string;
+  /**
+   * Tiptap JSON generated from the same source content.
+   */
+  contentJson: JSONContent;
+  /**
+   * Best-effort format classification used to choose the conversion path.
+   */
+  detectedFormat: PostContentFormat;
+}
+
+const htmlTagPattern = /<\/?[a-z][\s\S]*>/i;
+
+const markdownPatterns = [
+  /^#{1,6}\s+.+/m,
+  /\*\*[^*]+\*\*/m,
+  /__[^_]+__/m,
+  /\*[^*\n]+\*/m,
+  /_[^_\n]+_/m,
+  /\[[^\]]+\]\([^)]+\)/m,
+  /^\s*[-*+]\s+\S+/m,
+  /^\s*\d+\.\s+\S+/m,
+  /```[\s\S]*?```/m,
+  /`[^`\n]+`/m,
+  /^\s*>\s+\S+/m,
+  /!\[[^\]]*]\([^)]+\)/m,
+  /^\s*[-*_]{3,}\s*$/m,
+  /^\|.+\|$/m,
+];
+
+const headingPattern = /^#{1,6}\s+.+/m;
+
+/**
+ * Classifies post content as HTML or Markdown for defensive conversion.
+ *
+ * This intentionally biases toward HTML whenever real tags are present. Marble
+ * stores post content as HTML, so ambiguous input should stay on the official
+ * write path instead of being reinterpreted as Markdown.
+ */
+export function detectPostContentFormat(content: string): PostContentFormat {
+  const trimmed = content.trim();
+
+  if (!trimmed) {
+    return "html";
+  }
+
+  const matchCount = markdownPatterns.filter((pattern) =>
+    pattern.test(trimmed)
+  ).length;
+  const hasStrongMarkdownSignal =
+    matchCount >= 1 || headingPattern.test(trimmed);
+
+  if (htmlTagPattern.test(trimmed) && !hasStrongMarkdownSignal) {
+    return "html";
+  }
+
+  return hasStrongMarkdownSignal ? "markdown" : "html";
+}
+
+/**
+ * Converts post content into Marble's storage pair: HTML plus Tiptap JSON.
+ *
+ * The JSON is derived from the generated/supplied HTML so raw editor HTML
+ * embedded inside Markdown, such as figures and embeds, follows the same custom
+ * node parsing path as normal HTML writes.
+ */
+export async function normalizePostContent(
+  content: string
+): Promise<NormalizedPostContent> {
+  const detectedFormat = detectPostContentFormat(content);
+  const html =
+    detectedFormat === "markdown" ? await markdownToHtml(content) : content;
+
+  return {
+    html,
+    contentJson: htmlToTiptap(html),
+    detectedFormat,
+  };
+}

--- a/packages/parser/src/editor/types.ts
+++ b/packages/parser/src/editor/types.ts
@@ -1,0 +1,17 @@
+import type { JSONContent } from "@tiptap/core";
+
+/**
+ * Canonical empty Tiptap document used when source content is blank or cannot
+ * be converted safely.
+ */
+export const EMPTY_TIPTAP_DOC: JSONContent = { type: "doc", content: [] };
+
+/**
+ * Minimal DOM element shape used by linkedom and ProseMirror parsing on the
+ * server. It keeps custom parser helpers independent from browser-only DOM
+ * types while preserving enough API surface for extension `parseHTML` hooks.
+ */
+export type ParseableElement = HTMLElement & {
+  querySelector: (selector: string) => ParseableElement | null;
+  textContent: string | null;
+};

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -1,0 +1,14 @@
+/** biome-ignore-all lint/performance/noBarrelFile: Public parser package entrypoint. */
+export { htmlToMarkdown, htmlToTiptap } from "./editor/html";
+export {
+  MarkdownToTiptapParser,
+  markdownToHtml,
+  markdownToTiptap,
+} from "./editor/markdown";
+export {
+  detectPostContentFormat,
+  type NormalizedPostContent,
+  normalizePostContent,
+  type PostContentFormat,
+} from "./editor/normalize";
+export { EMPTY_TIPTAP_DOC } from "./editor/types";

--- a/packages/parser/tests/tiptap-parser.test.ts
+++ b/packages/parser/tests/tiptap-parser.test.ts
@@ -1,11 +1,14 @@
 import type { Tokens } from "marked";
 import { describe, expect, it } from "vitest";
 import {
+  detectPostContentFormat,
   EMPTY_TIPTAP_DOC,
+  htmlToMarkdown,
   htmlToTiptap,
   MarkdownToTiptapParser,
   markdownToTiptap,
-} from "../src/tiptap";
+  normalizePostContent,
+} from "../src";
 
 describe("htmlToTiptap", () => {
   it("converts HTML into Tiptap JSON", () => {
@@ -48,6 +51,106 @@ describe("htmlToTiptap", () => {
 
   it("returns an empty doc for empty HTML", () => {
     expect(htmlToTiptap("   ")).toEqual(EMPTY_TIPTAP_DOC);
+  });
+});
+
+describe("htmlToMarkdown", () => {
+  it("preserves Marble media figures as raw HTML", () => {
+    const html =
+      '<figure data-width="75" data-align="left"><img src="https://example.com/image.png" alt="Alt text"><figcaption>Caption</figcaption></figure>';
+
+    expect(htmlToMarkdown(html)).toBe(
+      '<figure data-width="75" data-align="left"><img src="https://example.com/image.png" alt="Alt text"><figcaption>Caption</figcaption></figure>'
+    );
+  });
+
+  it("preserves embeds as raw HTML and converts task lists", () => {
+    const html =
+      '<div data-youtube-video><iframe src="https://www.youtube.com/embed/video"></iframe></div><div data-twitter data-src="https://x.com/usemarble/status/1"></div><ul><li><input type="checkbox" checked="checked">Done</li><li><input type="checkbox">Todo</li></ul>';
+
+    expect(htmlToMarkdown(html)).toBe(
+      '<div data-youtube-video=""><iframe src="https://www.youtube.com/embed/video"></iframe></div>\n\n<div data-twitter="" data-src="https://x.com/usemarble/status/1"></div>\n\n- [x] Done\n- [ ] Todo'
+    );
+  });
+
+  it("does not emit indentation from formatted HTML text nodes", () => {
+    const html = `<h1>Title</h1>
+<p>Body</p>
+<ul>
+<li>One</li>
+<li>Two</li>
+</ul>
+<pre><code class="language-ts">const value = 42;
+</code></pre>`;
+
+    expect(htmlToMarkdown(html)).toBe(
+      "# Title\n\nBody\n\n- One\n- Two\n\n```ts\nconst value = 42;\n```"
+    );
+  });
+
+  it("preserves nested list structure", () => {
+    const html =
+      "<ul><li>Parent<ul><li>Child</li></ul></li><li>Sibling</li></ul>";
+
+    expect(htmlToMarkdown(html)).toBe("- Parent\n  - Child\n- Sibling");
+  });
+});
+
+describe("normalizePostContent", () => {
+  it("detects obvious markdown and converts it to HTML", async () => {
+    expect(detectPostContentFormat("# Title\n\nSome **bold** text")).toBe(
+      "markdown"
+    );
+
+    const result = await normalizePostContent("# Title\n\nSome **bold** text");
+
+    expect(result.detectedFormat).toBe("markdown");
+    expect(result.html.trim()).toBe(
+      "<h1>Title</h1>\n<p>Some <strong>bold</strong> text</p>"
+    );
+    expect(result.contentJson.content?.[0]?.type).toBe("heading");
+  });
+
+  it("detects single-list markdown writes", async () => {
+    expect(detectPostContentFormat("- item")).toBe("markdown");
+
+    const result = await normalizePostContent("- item");
+
+    expect(result.detectedFormat).toBe("markdown");
+    expect(result.html.trim()).toBe("<ul>\n<li>item</li>\n</ul>");
+    expect(result.contentJson.content?.[0]?.type).toBe("bulletList");
+  });
+
+  it("treats HTML with markdown-looking text as HTML", async () => {
+    expect(detectPostContentFormat("<p># Not a heading</p>")).toBe("html");
+
+    const result = await normalizePostContent("<p># Not a heading</p>");
+
+    expect(result.detectedFormat).toBe("html");
+    expect(result.html).toBe("<p># Not a heading</p>");
+    expect(result.contentJson.content?.[0]).toMatchObject({
+      type: "paragraph",
+      content: [{ type: "text", text: "# Not a heading" }],
+    });
+  });
+
+  it("preserves raw editor HTML embedded inside markdown", async () => {
+    const result = await normalizePostContent(
+      '# Title\n\n<figure data-width="75" data-align="left"><img src="https://example.com/image.png" alt="Alt text"><figcaption>Caption</figcaption></figure>'
+    );
+
+    expect(result.detectedFormat).toBe("markdown");
+    expect(result.html).toContain("<figure");
+    expect(result.contentJson.content?.[1]).toMatchObject({
+      type: "figure",
+      attrs: {
+        src: "https://example.com/image.png",
+        alt: "Alt text",
+        caption: "Caption",
+        width: "75",
+        align: "left",
+      },
+    });
   });
 });
 

--- a/packages/parser/tests/tiptap-parser.test.ts
+++ b/packages/parser/tests/tiptap-parser.test.ts
@@ -1,11 +1,14 @@
 import type { Tokens } from "marked";
 import { describe, expect, it } from "vitest";
 import {
+  detectPostContentFormat,
   EMPTY_TIPTAP_DOC,
+  htmlToMarkdown,
   htmlToTiptap,
   MarkdownToTiptapParser,
   markdownToTiptap,
-} from "../src/tiptap";
+  normalizePostContent,
+} from "../src";
 
 describe("htmlToTiptap", () => {
   it("converts HTML into Tiptap JSON", () => {
@@ -48,6 +51,89 @@ describe("htmlToTiptap", () => {
 
   it("returns an empty doc for empty HTML", () => {
     expect(htmlToTiptap("   ")).toEqual(EMPTY_TIPTAP_DOC);
+  });
+});
+
+describe("htmlToMarkdown", () => {
+  it("preserves Marble media figures as raw HTML", () => {
+    const html =
+      '<figure data-width="75" data-align="left"><img src="https://example.com/image.png" alt="Alt text"><figcaption>Caption</figcaption></figure>';
+
+    expect(htmlToMarkdown(html)).toBe(
+      '<figure data-width="75" data-align="left"><img src="https://example.com/image.png" alt="Alt text"><figcaption>Caption</figcaption></figure>'
+    );
+  });
+
+  it("preserves embeds as raw HTML and converts task lists", () => {
+    const html =
+      '<div data-youtube-video><iframe src="https://www.youtube.com/embed/video"></iframe></div><div data-twitter data-src="https://x.com/usemarble/status/1"></div><ul><li><input type="checkbox" checked="checked">Done</li><li><input type="checkbox">Todo</li></ul>';
+
+    expect(htmlToMarkdown(html)).toBe(
+      '<div data-youtube-video=""><iframe src="https://www.youtube.com/embed/video"></iframe></div>\n\n<div data-twitter="" data-src="https://x.com/usemarble/status/1"></div>\n\n- [x] Done\n- [ ] Todo'
+    );
+  });
+
+  it("does not emit indentation from formatted HTML text nodes", () => {
+    const html = `<h1>Title</h1>
+<p>Body</p>
+<ul>
+<li>One</li>
+<li>Two</li>
+</ul>
+<pre><code class="language-ts">const value = 42;
+</code></pre>`;
+
+    expect(htmlToMarkdown(html)).toBe(
+      "# Title\n\nBody\n\n- One\n- Two\n\n```ts\nconst value = 42;\n```"
+    );
+  });
+});
+
+describe("normalizePostContent", () => {
+  it("detects obvious markdown and converts it to HTML", async () => {
+    expect(detectPostContentFormat("# Title\n\nSome **bold** text")).toBe(
+      "markdown"
+    );
+
+    const result = await normalizePostContent("# Title\n\nSome **bold** text");
+
+    expect(result.detectedFormat).toBe("markdown");
+    expect(result.html.trim()).toBe(
+      "<h1>Title</h1>\n<p>Some <strong>bold</strong> text</p>"
+    );
+    expect(result.contentJson.content?.[0]?.type).toBe("heading");
+  });
+
+  it("treats HTML with markdown-looking text as HTML", async () => {
+    expect(detectPostContentFormat("<p># Not a heading</p>")).toBe("html");
+
+    const result = await normalizePostContent("<p># Not a heading</p>");
+
+    expect(result.detectedFormat).toBe("html");
+    expect(result.html).toBe("<p># Not a heading</p>");
+    expect(result.contentJson.content?.[0]).toMatchObject({
+      type: "paragraph",
+      content: [{ type: "text", text: "# Not a heading" }],
+    });
+  });
+
+  it("preserves raw editor HTML embedded inside markdown", async () => {
+    const result = await normalizePostContent(
+      '# Title\n\n<figure data-width="75" data-align="left"><img src="https://example.com/image.png" alt="Alt text"><figcaption>Caption</figcaption></figure>'
+    );
+
+    expect(result.detectedFormat).toBe("markdown");
+    expect(result.html).toContain("<figure");
+    expect(result.contentJson.content?.[1]).toMatchObject({
+      type: "figure",
+      attrs: {
+        src: "https://example.com/image.png",
+        alt: "Alt text",
+        caption: "Caption",
+        width: "75",
+        align: "left",
+      },
+    });
   });
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,9 +75,6 @@ importers:
       image-size:
         specifier: ^2.0.2
         version: 2.0.2
-      node-html-markdown:
-        specifier: ^2.0.0
-        version: 2.0.0
       resend:
         specifier: ^6.12.3
         version: 6.12.3(@react-email/render@2.0.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
@@ -223,9 +220,6 @@ importers:
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      node-html-markdown:
-        specifier: ^1.3.0
-        version: 1.3.0
       nuqs:
         specifier: ^2.8.4
         version: 2.8.4(next@16.2.6(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.94.2))(react@19.2.4)
@@ -8920,14 +8914,6 @@ packages:
   node-gyp-build@4.8.4:
     resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
     hasBin: true
-
-  node-html-markdown@1.3.0:
-    resolution: {integrity: sha512-OeFi3QwC/cPjvVKZ114tzzu+YoR+v9UXW5RwSXGUqGb0qCl0DvP406tzdL7SFn8pZrMyzXoisfG2zcuF9+zw4g==}
-    engines: {node: '>=10.0.0'}
-
-  node-html-markdown@2.0.0:
-    resolution: {integrity: sha512-DqUC3GGP7pwSYxS93SwHoP+qCw78xcMP6C6H2DuC8rPD2AweJRjBzQb5SdXpKtDlqAQ7hVotJcfhgU7hU5Gthw==}
-    engines: {node: '>=20.0.0'}
 
   node-html-parser@6.1.13:
     resolution: {integrity: sha512-qIsTMOY4C/dAa5Q5vsobRpOOvPfC4pB61UVW2uSwZNUp0QU/jCekTal1vMmbO0DgdHeLUJpv/ARmDqErVxA3Sg==}
@@ -21321,14 +21307,6 @@ snapshots:
       whatwg-url: 5.0.0
 
   node-gyp-build@4.8.4: {}
-
-  node-html-markdown@1.3.0:
-    dependencies:
-      node-html-parser: 6.1.13
-
-  node-html-markdown@2.0.0:
-    dependencies:
-      node-html-parser: 6.1.13
 
   node-html-parser@6.1.13:
     dependencies:


### PR DESCRIPTION
## Description

Adds an editor-aware parser package surface for Marble post content conversions:

- Splits the parser package into focused editor modules for HTML, Markdown, server-side Tiptap extensions, normalization, and shared types.
- Exposes parser utilities from `@marble/parser` instead of the old `@marble/parser/tiptap` subpath.
- Adds `htmlToMarkdown` that preserves Marble-specific editor nodes such as figures, videos, YouTube embeds, and Twitter embeds as raw HTML when Markdown cannot represent them faithfully.
- Adds `normalizePostContent` and wires API create/update writes through it so accidental Markdown input is converted to sanitized HTML before storage, while `contentJson` is recomputed from the stored HTML.
- Updates API Markdown read responses and CMS AI suggestion prompts to use the editor-aware serializer instead of generic `node-html-markdown`.
- Removes the `node-html-markdown` dependency from the workspace.
- Fixes existing lint issues in CMS validation imports and the editor link selector.

## Motivation and Context

The MCP/API contract expects post writes as HTML, but agents can accidentally send Markdown after reading Markdown responses. This change keeps HTML as the storage format while adding a defensive conversion path for obvious Markdown input. It also improves Markdown read output for editor-specific content that generic HTML-to-Markdown conversion dropped or flattened.

## How to Test

Automated checks run:

- `pnpm lint`
- `pnpm --filter @marble/parser test`
- `pnpm exec tsc -p packages/parser/tsconfig.json --noEmit`

Additional local API verification against `localhost:8787`:

- Created a draft post with Marble custom HTML elements and requested `format=markdown`; verified figures, videos, YouTube embeds, and Twitter embeds are preserved as raw HTML, while task lists, tables, and code blocks serialize cleanly.
- Created Markdown posts through `POST /v1/posts` and verified stored `format=html` content is valid HTML.
- Tested Markdown containing raw `<figure>` HTML and verified the figure survives storage and Markdown readback.
- Tested ambiguous HTML like `<p># Not a heading</p>` and verified it remains HTML instead of being reinterpreted as Markdown.
- Tested `PATCH /v1/posts/:identifier` with Markdown plus a raw figure and verified update normalization works.

## Screenshots (if applicable)

N/A

## Video Demo (if applicable)

N/A

## Types of Changes

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that alters existing functionality)
- [ ] 🎨 UI/UX Improvements
- [ ] ⚡ Performance Enhancement
- [x] 📖 Documentation (updates to README, docs, or comments)
