### PR TITLE
feat: add custom fields API support

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -15,6 +15,7 @@ import authorsRoutes from "./routes/authors";
 import cacheRoutes from "./routes/cache";
 import categoriesRoutes from "./routes/categories";
 import eventsRoutes from "./routes/events";
+import fieldsRoutes from "./routes/fields";
 import mediaRoutes from "./routes/media";
 import postsRoutes from "./routes/posts";
 import tagsRoutes from "./routes/tags";
@@ -62,6 +63,7 @@ legacyV1.route("/:workspaceId/tags", tagsRoutes);
 legacyV1.route("/:workspaceId/categories", categoriesRoutes);
 legacyV1.route("/:workspaceId/posts", postsRoutes);
 legacyV1.route("/:workspaceId/authors", authorsRoutes);
+legacyV1.route("/:workspaceId/fields", fieldsRoutes);
 
 // Mount legacy routes dispatcher - intercepts /v1/:workspaceId/* BEFORE apiKeyV1
 app.use("/v1/:workspaceId/*", async (c, next) => {
@@ -97,6 +99,7 @@ apiKeyV1.route("/categories", categoriesRoutes);
 apiKeyV1.route("/tags", tagsRoutes);
 apiKeyV1.route("/authors", authorsRoutes);
 apiKeyV1.route("/media", mediaRoutes);
+apiKeyV1.route("/fields", fieldsRoutes);
 
 // Mount apiKeyV1 under /v1 to automatically merge OpenAPI specs
 app.route("/v1", apiKeyV1);

--- a/apps/api/src/lib/cache.ts
+++ b/apps/api/src/lib/cache.ts
@@ -167,7 +167,7 @@ export function createCacheClient(url: string, token: string) {
      */
     async invalidateResource(
       workspaceId: string,
-      resource: "posts" | "categories" | "tags" | "authors" | "media"
+      resource: "posts" | "categories" | "tags" | "authors" | "media" | "fields"
     ): Promise<number> {
       return this.invalidate(`${CACHE_PREFIX}:${workspaceId}:${resource}:*`);
     },

--- a/apps/api/src/lib/fields.ts
+++ b/apps/api/src/lib/fields.ts
@@ -1,0 +1,305 @@
+import { z } from "zod";
+import { sanitizeHtml } from "@/lib/sanitize";
+
+export const CustomFieldValueSchema = z.union([
+  z.string(),
+  z.number(),
+  z.boolean(),
+  z.array(z.string()),
+  z.null(),
+]);
+
+export const CustomFieldsBodySchema = z.record(
+  z.string(),
+  CustomFieldValueSchema
+);
+
+export type CustomFieldInputValue = z.infer<typeof CustomFieldValueSchema>;
+export type CustomFieldsInput = z.infer<typeof CustomFieldsBodySchema>;
+
+/** Field definition shape required to validate and write post custom fields. */
+export interface FieldDefinition {
+  id: string;
+  key: string;
+  name: string;
+  type: string;
+  required: boolean;
+  options?: Array<{
+    value: string;
+    label: string;
+  }>;
+}
+
+/** Normalized field value ready to be persisted in the field_value table. */
+export interface FieldValueWrite {
+  fieldId: string;
+  fieldType: string;
+  value: string | null;
+}
+
+/** Public API error body returned when custom field validation fails. */
+export interface CustomFieldValidationError {
+  error: string;
+  message: string;
+  fields?: Array<{
+    key: string;
+    message: string;
+  }>;
+  key?: string;
+  type?: string;
+  invalidValues?: string[];
+}
+
+type ResolveMode = "create" | "update";
+
+const DateFieldSchema = z.iso.datetime({ offset: true }).or(z.iso.date());
+
+/** Returns true when rich text HTML has no meaningful visible text content. */
+function isRichTextContentEmpty(content: string) {
+  const plainText = content
+    .replace(/<br\s*\/?>/gi, " ")
+    .replace(/<\/?(p|div|li|ul|ol)>/gi, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&#160;/gi, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  return plainText.length === 0;
+}
+
+/** Builds a type-specific message for values that do not match a field type. */
+function invalidTypeMessage(field: FieldDefinition) {
+  switch (field.type) {
+    case "number":
+      return "Number fields must be numbers.";
+    case "boolean":
+      return "Boolean fields must be booleans.";
+    case "multiselect":
+      return "Multiselect fields must be arrays of option values.";
+    default:
+      return `${field.name} must match the configured field type.`;
+  }
+}
+
+/**
+ * Validates one custom field input value and converts it into the string/null
+ * representation stored by FieldValue.
+ */
+function validateFieldValue(
+  field: FieldDefinition,
+  rawValue: CustomFieldInputValue | undefined
+):
+  | { success: true; value: string | null }
+  | { success: false; message: string; invalidValues?: string[] } {
+  if (rawValue === undefined || rawValue === null) {
+    return field.required
+      ? { success: false, message: `${field.name} is required.` }
+      : { success: true, value: null };
+  }
+
+  if (field.type === "multiselect") {
+    if (!Array.isArray(rawValue)) {
+      return { success: false, message: invalidTypeMessage(field) };
+    }
+
+    if (rawValue.length === 0) {
+      return field.required
+        ? { success: false, message: `${field.name} is required.` }
+        : { success: true, value: null };
+    }
+
+    const allowedValues = new Set(
+      (field.options ?? []).map((option) => option.value)
+    );
+    const invalidValues = rawValue.filter((value) => !allowedValues.has(value));
+
+    if (invalidValues.length > 0) {
+      return {
+        success: false,
+        message: "Selected values must match the configured options.",
+        invalidValues,
+      };
+    }
+
+    return { success: true, value: JSON.stringify([...new Set(rawValue)]) };
+  }
+
+  if (Array.isArray(rawValue)) {
+    return { success: false, message: invalidTypeMessage(field) };
+  }
+
+  switch (field.type) {
+    case "text": {
+      if (typeof rawValue !== "string") {
+        return { success: false, message: "Text fields must be strings." };
+      }
+
+      const value = rawValue.trim();
+      if (value === "") {
+        return field.required
+          ? { success: false, message: `${field.name} is required.` }
+          : { success: true, value: null };
+      }
+
+      return { success: true, value };
+    }
+    case "number": {
+      if (typeof rawValue !== "number" || !Number.isFinite(rawValue)) {
+        return { success: false, message: invalidTypeMessage(field) };
+      }
+
+      return { success: true, value: String(rawValue) };
+    }
+    case "boolean": {
+      if (typeof rawValue !== "boolean") {
+        return { success: false, message: invalidTypeMessage(field) };
+      }
+
+      return { success: true, value: rawValue ? "true" : "false" };
+    }
+    case "date": {
+      if (typeof rawValue !== "string") {
+        return {
+          success: false,
+          message: "Date fields must be ISO 8601 strings.",
+        };
+      }
+
+      const value = rawValue.trim();
+      if (value === "") {
+        return field.required
+          ? { success: false, message: `${field.name} is required.` }
+          : { success: true, value: null };
+      }
+
+      const result = DateFieldSchema.safeParse(value);
+      if (!result.success) {
+        return {
+          success: false,
+          message: "Date fields must be ISO 8601 dates or datetimes.",
+        };
+      }
+
+      return { success: true, value };
+    }
+    case "richtext": {
+      if (typeof rawValue !== "string") {
+        return {
+          success: false,
+          message: "Rich text fields must be HTML strings.",
+        };
+      }
+
+      const value = rawValue.trim();
+      if (value === "" || isRichTextContentEmpty(value)) {
+        return field.required
+          ? { success: false, message: `${field.name} is required.` }
+          : { success: true, value: null };
+      }
+
+      return { success: true, value: sanitizeHtml(value) };
+    }
+    case "select": {
+      if (typeof rawValue !== "string") {
+        return {
+          success: false,
+          message: "Select fields must be option value strings.",
+        };
+      }
+
+      const value = rawValue.trim();
+      if (value === "") {
+        return field.required
+          ? { success: false, message: `${field.name} is required.` }
+          : { success: true, value: null };
+      }
+
+      const allowedValues = new Set(
+        (field.options ?? []).map((option) => option.value)
+      );
+      if (!allowedValues.has(value)) {
+        return {
+          success: false,
+          message: "Selected value must match a configured option.",
+          invalidValues: [value],
+        };
+      }
+
+      return { success: true, value };
+    }
+    default:
+      return {
+        success: false,
+        message: `${field.name} has an unsupported field type.`,
+      };
+  }
+}
+
+/**
+ * Resolves API-provided custom field values by field key.
+ *
+ * Create mode validates every workspace field so required fields must be
+ * present. Update mode validates only provided keys so omitted fields remain
+ * unchanged. This function never creates fields or options implicitly.
+ */
+export function resolveCustomFieldValuesByKey(
+  fields: FieldDefinition[],
+  input: CustomFieldsInput | undefined,
+  mode: ResolveMode
+):
+  | { success: true; values: FieldValueWrite[] }
+  | { success: false; error: CustomFieldValidationError } {
+  const values: FieldValueWrite[] = [];
+  const json = input ?? {};
+  const fieldsByKey = new Map(fields.map((field) => [field.key, field]));
+  const invalidKeys = Object.keys(json).filter((key) => !fieldsByKey.has(key));
+
+  if (invalidKeys.length > 0) {
+    return {
+      success: false,
+      error: {
+        error: "Invalid custom fields",
+        message: "One or more custom fields do not exist in this workspace.",
+        fields: invalidKeys.map((key) => ({
+          key,
+          message: "Field does not exist.",
+        })),
+      },
+    };
+  }
+
+  const fieldsToValidate =
+    mode === "create"
+      ? fields
+      : Object.keys(json)
+          .map((key) => fieldsByKey.get(key))
+          .filter((field) => field !== undefined);
+
+  for (const field of fieldsToValidate) {
+    const validation = validateFieldValue(field, json[field.key]);
+
+    if (!validation.success) {
+      return {
+        success: false,
+        error: {
+          error: "Invalid custom field value",
+          key: field.key,
+          type: field.type,
+          message: validation.message,
+          ...(validation.invalidValues
+            ? { invalidValues: validation.invalidValues }
+            : {}),
+        },
+      };
+    }
+
+    values.push({
+      fieldId: field.id,
+      fieldType: field.type,
+      value: validation.value,
+    });
+  }
+
+  return { success: true, values };
+}

--- a/apps/api/src/lib/fields.ts
+++ b/apps/api/src/lib/fields.ts
@@ -191,14 +191,14 @@ function validateFieldValue(
         };
       }
 
-      const value = rawValue.trim();
-      if (value === "" || isRichTextContentEmpty(value)) {
+      const sanitized = sanitizeHtml(rawValue).trim();
+      if (sanitized === "" || isRichTextContentEmpty(sanitized)) {
         return field.required
           ? { success: false, message: `${field.name} is required.` }
           : { success: true, value: null };
       }
 
-      return { success: true, value: sanitizeHtml(value) };
+      return { success: true, value: sanitized };
     }
     case "select": {
       if (typeof rawValue !== "string") {
@@ -277,7 +277,10 @@ export function resolveCustomFieldValuesByKey(
           .filter((field) => field !== undefined);
 
   for (const field of fieldsToValidate) {
-    const validation = validateFieldValue(field, json[field.key]);
+    const rawValue = Object.hasOwn(json, field.key)
+      ? json[field.key]
+      : undefined;
+    const validation = validateFieldValue(field, rawValue);
 
     if (!validation.success) {
       return {

--- a/apps/api/src/routes/fields.ts
+++ b/apps/api/src/routes/fields.ts
@@ -1,0 +1,598 @@
+import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
+import { createCacheClient } from "@/lib/cache";
+import { createDbClient } from "@/lib/db";
+import { requireWorkspaceId } from "@/lib/workspace";
+import {
+  ConflictSchema,
+  DeleteResponseSchema,
+  ErrorSchema,
+  ForbiddenSchema,
+  IdentifierParamSchema,
+  NotFoundSchema,
+  ServerErrorSchema,
+} from "@/schemas/common";
+import {
+  CreateFieldBodySchema,
+  FieldResponseSchema,
+  FieldsListResponseSchema,
+  UpdateFieldBodySchema,
+} from "@/schemas/fields";
+import type { ApiKeyApp } from "@/types/env";
+
+function formatValidationPath(path: PropertyKey[]) {
+  return path.length > 0 ? path.join(".") : "body";
+}
+
+const fields = new OpenAPIHono<ApiKeyApp>({
+  defaultHook: (result, c) => {
+    if (result.success) {
+      return;
+    }
+
+    return c.json(
+      {
+        error: "Invalid request body",
+        message: "Validation failed",
+        details: result.error.issues.map((issue) => ({
+          field: formatValidationPath(issue.path),
+          message: issue.message,
+        })),
+      },
+      400
+    );
+  },
+});
+
+const FieldParamsSchema = z.object({
+  identifier: IdentifierParamSchema.openapi({
+    example: "audience",
+    description: "Field ID or key",
+  }),
+});
+
+function buildFieldOptionWrites(
+  options: Array<{ value: string; label: string }>
+) {
+  return options.map((option, index) => ({
+    value: option.value,
+    label: option.label,
+    position: index,
+  }));
+}
+
+function areFieldOptionsEqual(
+  nextOptions: Array<{ value: string; label: string }>,
+  currentOptions: Array<{ value: string; label: string }>
+) {
+  if (nextOptions.length !== currentOptions.length) {
+    return false;
+  }
+
+  return nextOptions.every((option, index) => {
+    const currentOption = currentOptions[index];
+    return (
+      currentOption !== undefined &&
+      option.value === currentOption.value &&
+      option.label === currentOption.label
+    );
+  });
+}
+
+function isUniqueFieldKeyConflict(error: unknown) {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    (error as Error & { code?: string }).code === "P2002"
+  );
+}
+
+const listFieldsRoute = createRoute({
+  method: "get",
+  path: "/",
+  tags: ["Fields"],
+  summary: "List fields",
+  description: "Get all custom field definitions for the workspace.",
+  responses: {
+    200: {
+      content: { "application/json": { schema: FieldsListResponseSchema } },
+      description: "List of custom field definitions",
+    },
+    500: {
+      content: { "application/json": { schema: ServerErrorSchema } },
+      description: "Server error",
+    },
+  },
+});
+
+const getFieldRoute = createRoute({
+  method: "get",
+  path: "/{identifier}",
+  tags: ["Fields"],
+  summary: "Get field",
+  description: "Get a single custom field definition by ID or key.",
+  request: {
+    params: FieldParamsSchema,
+  },
+  responses: {
+    200: {
+      content: { "application/json": { schema: FieldResponseSchema } },
+      description: "The requested field definition",
+    },
+    404: {
+      content: { "application/json": { schema: NotFoundSchema } },
+      description: "Field not found",
+    },
+    500: {
+      content: { "application/json": { schema: ServerErrorSchema } },
+      description: "Server error",
+    },
+  },
+});
+
+const createFieldRoute = createRoute({
+  method: "post",
+  path: "/",
+  tags: ["Fields"],
+  summary: "Create field",
+  description: "Create a custom field definition. Requires a private API key.",
+  request: {
+    body: {
+      content: { "application/json": { schema: CreateFieldBodySchema } },
+      required: true,
+    },
+  },
+  responses: {
+    201: {
+      content: { "application/json": { schema: FieldResponseSchema } },
+      description: "Field created successfully",
+    },
+    400: {
+      content: { "application/json": { schema: ErrorSchema } },
+      description: "Invalid request body",
+    },
+    403: {
+      content: { "application/json": { schema: ForbiddenSchema } },
+      description: "API key missing the required field write scope",
+    },
+    409: {
+      content: { "application/json": { schema: ConflictSchema } },
+      description: "Field with this key already exists",
+    },
+    500: {
+      content: { "application/json": { schema: ServerErrorSchema } },
+      description: "Server error",
+    },
+  },
+});
+
+const updateFieldRoute = createRoute({
+  method: "patch",
+  path: "/{identifier}",
+  tags: ["Fields"],
+  summary: "Update field",
+  description:
+    "Update a custom field definition by ID or key. Type and options cannot be changed after values have been saved.",
+  request: {
+    params: FieldParamsSchema,
+    body: {
+      content: { "application/json": { schema: UpdateFieldBodySchema } },
+      required: true,
+    },
+  },
+  responses: {
+    200: {
+      content: { "application/json": { schema: FieldResponseSchema } },
+      description: "Field updated successfully",
+    },
+    400: {
+      content: { "application/json": { schema: ErrorSchema } },
+      description: "Invalid request body or unsafe schema change",
+    },
+    403: {
+      content: { "application/json": { schema: ForbiddenSchema } },
+      description: "API key missing the required field write scope",
+    },
+    404: {
+      content: { "application/json": { schema: NotFoundSchema } },
+      description: "Field not found",
+    },
+    409: {
+      content: { "application/json": { schema: ConflictSchema } },
+      description: "Field key conflict",
+    },
+    500: {
+      content: { "application/json": { schema: ServerErrorSchema } },
+      description: "Server error",
+    },
+  },
+});
+
+const deleteFieldRoute = createRoute({
+  method: "delete",
+  path: "/{identifier}",
+  tags: ["Fields"],
+  summary: "Delete field",
+  description:
+    "Delete a custom field definition by ID or key. Requires a private API key.",
+  request: {
+    params: FieldParamsSchema,
+  },
+  responses: {
+    200: {
+      content: { "application/json": { schema: DeleteResponseSchema } },
+      description: "Field deleted successfully",
+    },
+    403: {
+      content: { "application/json": { schema: ForbiddenSchema } },
+      description: "API key missing the required field write scope",
+    },
+    404: {
+      content: { "application/json": { schema: NotFoundSchema } },
+      description: "Field not found",
+    },
+    500: {
+      content: { "application/json": { schema: ServerErrorSchema } },
+      description: "Server error",
+    },
+  },
+});
+
+fields.openapi(listFieldsRoute, async (c) => {
+  try {
+    const workspaceId = requireWorkspaceId(c);
+    const db = createDbClient(c.env);
+
+    const fieldList = await db.field.findMany({
+      where: { workspaceId },
+      include: {
+        options: {
+          orderBy: [{ position: "asc" }, { createdAt: "asc" }],
+        },
+      },
+      orderBy: [{ position: "asc" }, { createdAt: "asc" }],
+    });
+
+    return c.json({ fields: fieldList }, 200 as const);
+  } catch (error) {
+    console.error("Error fetching fields:", error);
+    return c.json(
+      {
+        error: "Failed to fetch fields",
+        message: "An unexpected error occurred",
+      },
+      500 as const
+    );
+  }
+});
+
+fields.openapi(getFieldRoute, async (c) => {
+  try {
+    const workspaceId = requireWorkspaceId(c);
+    const db = createDbClient(c.env);
+    const { identifier } = c.req.valid("param");
+
+    const field = await db.field.findFirst({
+      where: {
+        workspaceId,
+        OR: [{ id: identifier }, { key: identifier }],
+      },
+      include: {
+        options: {
+          orderBy: [{ position: "asc" }, { createdAt: "asc" }],
+        },
+      },
+    });
+
+    if (!field) {
+      return c.json(
+        {
+          error: "Field not found",
+          message: "The requested custom field does not exist",
+        },
+        404 as const
+      );
+    }
+
+    return c.json({ field }, 200 as const);
+  } catch (error) {
+    console.error("Error fetching field:", error);
+    return c.json({ error: "Failed to fetch field" }, 500 as const);
+  }
+});
+
+fields.openapi(createFieldRoute, async (c) => {
+  try {
+    const workspaceId = requireWorkspaceId(c);
+    const db = createDbClient(c.env);
+    const cache = createCacheClient(c.env.REDIS_URL, c.env.REDIS_TOKEN);
+    const body = c.req.valid("json");
+
+    const existing = await db.field.findFirst({
+      where: {
+        workspaceId,
+        key: body.key,
+      },
+    });
+
+    if (existing) {
+      return c.json(
+        {
+          error: "Field key already in use",
+          message: "A field with this key already exists in this workspace",
+        },
+        409 as const
+      );
+    }
+
+    const maxPosition = await db.field.aggregate({
+      where: { workspaceId },
+      _max: { position: true },
+    });
+
+    const field = await db.field.create({
+      data: {
+        key: body.key,
+        name: body.name,
+        description: body.description?.trim() || null,
+        type: body.type,
+        required: body.required ?? false,
+        position: (maxPosition._max.position ?? -1) + 1,
+        workspaceId,
+        options:
+          (body.options ?? []).length > 0
+            ? { create: buildFieldOptionWrites(body.options ?? []) }
+            : undefined,
+      },
+      include: {
+        options: {
+          orderBy: [{ position: "asc" }, { createdAt: "asc" }],
+        },
+      },
+    });
+
+    c.executionCtx.waitUntil(cache.invalidateResource(workspaceId, "fields"));
+    c.executionCtx.waitUntil(cache.invalidateResource(workspaceId, "posts"));
+
+    return c.json({ field }, 201 as const);
+  } catch (error) {
+    if (isUniqueFieldKeyConflict(error)) {
+      return c.json(
+        {
+          error: "Field key already in use",
+          message: "A field with this key already exists in this workspace",
+        },
+        409 as const
+      );
+    }
+
+    console.error("Error creating field:", error);
+    return c.json(
+      {
+        error: "Failed to create field",
+        message: "An unexpected error occurred",
+      },
+      500 as const
+    );
+  }
+});
+
+fields.openapi(updateFieldRoute, async (c) => {
+  try {
+    const workspaceId = requireWorkspaceId(c);
+    const db = createDbClient(c.env);
+    const cache = createCacheClient(c.env.REDIS_URL, c.env.REDIS_TOKEN);
+    const { identifier } = c.req.valid("param");
+    const body = c.req.valid("json");
+
+    const existingField = await db.field.findFirst({
+      where: {
+        workspaceId,
+        OR: [{ id: identifier }, { key: identifier }],
+      },
+      include: {
+        options: {
+          orderBy: [{ position: "asc" }, { createdAt: "asc" }],
+        },
+      },
+    });
+
+    if (!existingField) {
+      return c.json(
+        {
+          error: "Field not found",
+          message: "The requested custom field does not exist",
+        },
+        404 as const
+      );
+    }
+
+    const effectiveType = body.type ?? existingField.type;
+    const existingOptions = existingField.options.map((option) => ({
+      value: option.value,
+      label: option.label,
+    }));
+    const effectiveOptions = body.options ?? existingOptions;
+    const requiresOptions =
+      effectiveType === "select" || effectiveType === "multiselect";
+
+    if (requiresOptions && effectiveOptions.length === 0) {
+      return c.json(
+        {
+          error: "Invalid field options",
+          message: "Select fields must define at least one option",
+        },
+        400 as const
+      );
+    }
+
+    if (!requiresOptions && effectiveOptions.length > 0) {
+      return c.json(
+        {
+          error: "Invalid field options",
+          message: "Only select and multiselect fields can define options",
+        },
+        400 as const
+      );
+    }
+
+    const typeChanged =
+      body.type !== undefined && body.type !== existingField.type;
+    const optionsChanged =
+      body.options !== undefined &&
+      !areFieldOptionsEqual(body.options, existingOptions);
+
+    if (body.key && body.key !== existingField.key) {
+      const keyConflict = await db.field.findFirst({
+        where: {
+          workspaceId,
+          key: body.key,
+          id: { not: existingField.id },
+        },
+      });
+
+      if (keyConflict) {
+        return c.json(
+          {
+            error: "Field key already in use",
+            message: "A field with this key already exists in this workspace",
+          },
+          409 as const
+        );
+      }
+    }
+
+    const field = await db.$transaction(async (tx) => {
+      if (typeChanged || optionsChanged) {
+        const fieldValueCount = await tx.fieldValue.count({
+          where: {
+            fieldId: existingField.id,
+            workspaceId,
+          },
+        });
+
+        if (fieldValueCount > 0) {
+          return null;
+        }
+      }
+
+      return tx.field.update({
+        where: {
+          id_workspaceId: {
+            id: existingField.id,
+            workspaceId,
+          },
+        },
+        data: {
+          ...(body.key !== undefined ? { key: body.key } : {}),
+          ...(body.name !== undefined ? { name: body.name } : {}),
+          ...(body.description !== undefined
+            ? { description: body.description?.trim() || null }
+            : {}),
+          ...(body.type !== undefined ? { type: body.type } : {}),
+          ...(body.required !== undefined ? { required: body.required } : {}),
+          options:
+            body.options !== undefined || !requiresOptions
+              ? {
+                  deleteMany: {},
+                  create: requiresOptions
+                    ? buildFieldOptionWrites(effectiveOptions)
+                    : [],
+                }
+              : undefined,
+        },
+        include: {
+          options: {
+            orderBy: [{ position: "asc" }, { createdAt: "asc" }],
+          },
+        },
+      });
+    });
+
+    if (!field) {
+      return c.json(
+        {
+          error: "Unsafe field change",
+          message:
+            "This field already has saved values. You can't change its type or options.",
+        },
+        400 as const
+      );
+    }
+
+    c.executionCtx.waitUntil(cache.invalidateResource(workspaceId, "fields"));
+    c.executionCtx.waitUntil(cache.invalidateResource(workspaceId, "posts"));
+
+    return c.json({ field }, 200 as const);
+  } catch (error) {
+    if (isUniqueFieldKeyConflict(error)) {
+      return c.json(
+        {
+          error: "Field key already in use",
+          message: "A field with this key already exists in this workspace",
+        },
+        409 as const
+      );
+    }
+
+    console.error("Error updating field:", error);
+    return c.json(
+      {
+        error: "Failed to update field",
+        message: "An unexpected error occurred",
+      },
+      500 as const
+    );
+  }
+});
+
+fields.openapi(deleteFieldRoute, async (c) => {
+  try {
+    const workspaceId = requireWorkspaceId(c);
+    const db = createDbClient(c.env);
+    const cache = createCacheClient(c.env.REDIS_URL, c.env.REDIS_TOKEN);
+    const { identifier } = c.req.valid("param");
+
+    const existingField = await db.field.findFirst({
+      where: {
+        workspaceId,
+        OR: [{ id: identifier }, { key: identifier }],
+      },
+      select: { id: true },
+    });
+
+    if (!existingField) {
+      return c.json(
+        {
+          error: "Field not found",
+          message: "The requested custom field does not exist",
+        },
+        404 as const
+      );
+    }
+
+    await db.field.delete({
+      where: {
+        id_workspaceId: {
+          id: existingField.id,
+          workspaceId,
+        },
+      },
+    });
+
+    c.executionCtx.waitUntil(cache.invalidateResource(workspaceId, "fields"));
+    c.executionCtx.waitUntil(cache.invalidateResource(workspaceId, "posts"));
+
+    return c.json({ id: existingField.id }, 200 as const);
+  } catch (error) {
+    console.error("Error deleting field:", error);
+    return c.json(
+      {
+        error: "Failed to delete field",
+        message: "An unexpected error occurred",
+      },
+      500 as const
+    );
+  }
+});
+
+export default fields;

--- a/apps/api/src/routes/fields.ts
+++ b/apps/api/src/routes/fields.ts
@@ -1,4 +1,5 @@
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
+import { Prisma } from "@marble/db/workers";
 import { createCacheClient } from "@/lib/cache";
 import { createDbClient } from "@/lib/db";
 import { requireWorkspaceId } from "@/lib/workspace";
@@ -83,6 +84,14 @@ function isUniqueFieldKeyConflict(error: unknown) {
     error instanceof Error &&
     "code" in error &&
     (error as Error & { code?: string }).code === "P2002"
+  );
+}
+
+function isTransactionConflict(error: unknown) {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    (error as Error & { code?: string }).code === "P2034"
   );
 }
 
@@ -461,52 +470,55 @@ fields.openapi(updateFieldRoute, async (c) => {
       }
     }
 
-    const field = await db.$transaction(async (tx) => {
-      if (typeChanged || optionsChanged) {
-        const fieldValueCount = await tx.fieldValue.count({
+    const field = await db.$transaction(
+      async (tx) => {
+        if (typeChanged || optionsChanged) {
+          const fieldValueCount = await tx.fieldValue.count({
+            where: {
+              fieldId: existingField.id,
+              workspaceId,
+            },
+          });
+
+          if (fieldValueCount > 0) {
+            return null;
+          }
+        }
+
+        return tx.field.update({
           where: {
-            fieldId: existingField.id,
-            workspaceId,
+            id_workspaceId: {
+              id: existingField.id,
+              workspaceId,
+            },
+          },
+          data: {
+            ...(body.key !== undefined ? { key: body.key } : {}),
+            ...(body.name !== undefined ? { name: body.name } : {}),
+            ...(body.description !== undefined
+              ? { description: body.description?.trim() || null }
+              : {}),
+            ...(body.type !== undefined ? { type: body.type } : {}),
+            ...(body.required !== undefined ? { required: body.required } : {}),
+            options:
+              body.options !== undefined || !requiresOptions
+                ? {
+                    deleteMany: {},
+                    create: requiresOptions
+                      ? buildFieldOptionWrites(effectiveOptions)
+                      : [],
+                  }
+                : undefined,
+          },
+          include: {
+            options: {
+              orderBy: [{ position: "asc" }, { createdAt: "asc" }],
+            },
           },
         });
-
-        if (fieldValueCount > 0) {
-          return null;
-        }
-      }
-
-      return tx.field.update({
-        where: {
-          id_workspaceId: {
-            id: existingField.id,
-            workspaceId,
-          },
-        },
-        data: {
-          ...(body.key !== undefined ? { key: body.key } : {}),
-          ...(body.name !== undefined ? { name: body.name } : {}),
-          ...(body.description !== undefined
-            ? { description: body.description?.trim() || null }
-            : {}),
-          ...(body.type !== undefined ? { type: body.type } : {}),
-          ...(body.required !== undefined ? { required: body.required } : {}),
-          options:
-            body.options !== undefined || !requiresOptions
-              ? {
-                  deleteMany: {},
-                  create: requiresOptions
-                    ? buildFieldOptionWrites(effectiveOptions)
-                    : [],
-                }
-              : undefined,
-        },
-        include: {
-          options: {
-            orderBy: [{ position: "asc" }, { createdAt: "asc" }],
-          },
-        },
-      });
-    });
+      },
+      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable }
+    );
 
     if (!field) {
       return c.json(
@@ -529,6 +541,16 @@ fields.openapi(updateFieldRoute, async (c) => {
         {
           error: "Field key already in use",
           message: "A field with this key already exists in this workspace",
+        },
+        409 as const
+      );
+    }
+
+    if (isTransactionConflict(error)) {
+      return c.json(
+        {
+          error: "Field update conflict",
+          message: "This field was updated concurrently. Please retry.",
         },
         409 as const
       );

--- a/apps/api/src/routes/posts.ts
+++ b/apps/api/src/routes/posts.ts
@@ -9,6 +9,7 @@ import {
 import { cacheKey, createCacheClient, hashQueryParams } from "@/lib/cache";
 import { createDbClient } from "@/lib/db";
 import { emitEvent } from "@/lib/events";
+import { resolveCustomFieldValuesByKey } from "@/lib/fields";
 import { buildFieldsObject, buildStatusFilter } from "@/lib/posts";
 import { sanitizeHtml } from "@/lib/sanitize";
 import { requireWorkspaceId } from "@/lib/workspace";
@@ -641,12 +642,41 @@ posts.openapi(createPostRoute, async (c) => {
     // The first author in the list becomes the primary author
     const primaryAuthorId = authorIds[0];
 
-    // 5. Determine publishedAt
+    // 5. Resolve custom fields by field key
+    const customFieldDefinitions = await db.field.findMany({
+      where: { workspaceId },
+      select: {
+        id: true,
+        key: true,
+        name: true,
+        type: true,
+        required: true,
+        options: {
+          select: {
+            value: true,
+            label: true,
+          },
+          orderBy: [{ position: "asc" }, { createdAt: "asc" }],
+        },
+      },
+    });
+
+    const customFieldWrites = resolveCustomFieldValuesByKey(
+      customFieldDefinitions,
+      body.fields,
+      "create"
+    );
+
+    if (!customFieldWrites.success) {
+      return c.json(customFieldWrites.error, 400 as const);
+    }
+
+    // 6. Determine publishedAt
     const publishedAt = body.publishedAt
       ? new Date(body.publishedAt)
       : new Date();
 
-    // 6. Create the post
+    // 7. Create the post
     const normalizedContent = await normalizePostContent(body.content);
     const sanitizedContent = sanitizeHtml(normalizedContent.html);
     let contentJson = EMPTY_TIPTAP_DOC;
@@ -658,40 +688,59 @@ posts.openapi(createPostRoute, async (c) => {
       contentJson = EMPTY_TIPTAP_DOC;
     }
 
-    const postCreated = await db.post.create({
-      data: {
-        title: body.title,
-        content: sanitizedContent,
-        contentJson,
-        description: body.description,
-        slug: body.slug,
-        categoryId: body.categoryId,
-        status: body.status,
-        featured: body.featured ?? false,
-        coverImage: body.coverImage ?? null,
-        publishedAt,
-        workspaceId,
-        primaryAuthorId,
-        tags:
-          validTagIds.length > 0
-            ? { connect: validTagIds.map((id) => ({ id })) }
-            : undefined,
-        authors: {
-          connect: authorIds.map((id) => ({ id })),
+    const postCreated = await db.$transaction(async (tx) => {
+      const createdPost = await tx.post.create({
+        data: {
+          title: body.title,
+          content: sanitizedContent,
+          contentJson,
+          description: body.description,
+          slug: body.slug,
+          categoryId: body.categoryId,
+          status: body.status,
+          featured: body.featured ?? false,
+          coverImage: body.coverImage ?? null,
+          publishedAt,
+          workspaceId,
+          primaryAuthorId,
+          tags:
+            validTagIds.length > 0
+              ? { connect: validTagIds.map((id) => ({ id })) }
+              : undefined,
+          authors: {
+            connect: authorIds.map((id) => ({ id })),
+          },
         },
-      },
-      select: {
-        id: true,
-        slug: true,
-        title: true,
-        status: true,
-        featured: true,
-        publishedAt: true,
-        createdAt: true,
-      },
+        select: {
+          id: true,
+          slug: true,
+          title: true,
+          status: true,
+          featured: true,
+          publishedAt: true,
+          createdAt: true,
+        },
+      });
+
+      for (const { fieldId, value } of customFieldWrites.values) {
+        if (value === null) {
+          continue;
+        }
+
+        await tx.fieldValue.create({
+          data: {
+            postId: createdPost.id,
+            fieldId,
+            workspaceId,
+            value,
+          },
+        });
+      }
+
+      return createdPost;
     });
 
-    // 7. Invalidate cache
+    // 8. Invalidate cache
     c.executionCtx.waitUntil(cache.invalidateResource(workspaceId, "posts"));
     c.executionCtx.waitUntil(cache.invalidateResource(workspaceId, "tags"));
     c.executionCtx.waitUntil(
@@ -938,7 +987,44 @@ posts.openapi(updatePostRoute, async (c) => {
       primaryAuthorId = orderedAuthorIds[0];
     }
 
-    // 6. Build update data
+    // 6. Resolve custom fields by field key when provided
+    let customFieldWrites:
+      | { fieldId: string; fieldType: string; value: string | null }[]
+      | undefined;
+
+    if (body.fields !== undefined) {
+      const customFieldDefinitions = await db.field.findMany({
+        where: { workspaceId },
+        select: {
+          id: true,
+          key: true,
+          name: true,
+          type: true,
+          required: true,
+          options: {
+            select: {
+              value: true,
+              label: true,
+            },
+            orderBy: [{ position: "asc" }, { createdAt: "asc" }],
+          },
+        },
+      });
+
+      const resolvedCustomFields = resolveCustomFieldValuesByKey(
+        customFieldDefinitions,
+        body.fields,
+        "update"
+      );
+
+      if (!resolvedCustomFields.success) {
+        return c.json(resolvedCustomFields.error, 400 as const);
+      }
+
+      customFieldWrites = resolvedCustomFields.values;
+    }
+
+    // 7. Build update data
     const updateData: Record<string, unknown> = {};
     if (body.title !== undefined) {
       updateData.title = body.title;
@@ -988,22 +1074,61 @@ posts.openapi(updatePostRoute, async (c) => {
     if (primaryAuthorId) {
       updateData.primaryAuthorId = primaryAuthorId;
     }
+    if (customFieldWrites !== undefined) {
+      updateData.updatedAt = new Date();
+    }
 
-    const postUpdated = await db.post.update({
-      where: { id: existingPost.id },
-      data: updateData,
-      select: {
-        id: true,
-        slug: true,
-        title: true,
-        status: true,
-        featured: true,
-        publishedAt: true,
-        updatedAt: true,
-      },
+    const postUpdated = await db.$transaction(async (tx) => {
+      const updatedPost = await tx.post.update({
+        where: { id: existingPost.id },
+        data: updateData,
+        select: {
+          id: true,
+          slug: true,
+          title: true,
+          status: true,
+          featured: true,
+          publishedAt: true,
+          updatedAt: true,
+        },
+      });
+
+      for (const { fieldId, value } of customFieldWrites ?? []) {
+        if (value === null) {
+          await tx.fieldValue.deleteMany({
+            where: {
+              postId: existingPost.id,
+              fieldId,
+              workspaceId,
+            },
+          });
+          continue;
+        }
+
+        await tx.fieldValue.upsert({
+          where: {
+            postId_fieldId: {
+              postId: existingPost.id,
+              fieldId,
+            },
+          },
+          update: {
+            value,
+            workspaceId,
+          },
+          create: {
+            postId: existingPost.id,
+            fieldId,
+            workspaceId,
+            value,
+          },
+        });
+      }
+
+      return updatedPost;
     });
 
-    // 7. Invalidate cache
+    // 8. Invalidate cache
     c.executionCtx.waitUntil(cache.invalidateResource(workspaceId, "posts"));
     c.executionCtx.waitUntil(cache.invalidateResource(workspaceId, "tags"));
     c.executionCtx.waitUntil(
@@ -1011,7 +1136,7 @@ posts.openapi(updatePostRoute, async (c) => {
     );
     c.executionCtx.waitUntil(cache.invalidateResource(workspaceId, "authors"));
 
-    // 8. Emit events
+    // 9. Emit events
     const apiKeyId = c.get("apiKeyId");
     let eventType: "post_published" | "post_unpublished" | "post_updated";
 

--- a/apps/api/src/schemas/fields.ts
+++ b/apps/api/src/schemas/fields.ts
@@ -1,0 +1,200 @@
+import { z } from "@hono/zod-openapi";
+
+export const FieldTypeSchema = z
+  .enum([
+    "text",
+    "number",
+    "boolean",
+    "date",
+    "richtext",
+    "select",
+    "multiselect",
+  ])
+  .openapi("FieldType");
+
+export const FieldOptionSchema = z
+  .object({
+    id: z.string().openapi({ example: "cryitfjp9012ab34cdefghij" }),
+    value: z.string().openapi({ example: "developers" }),
+    label: z.string().openapi({ example: "Developers" }),
+    position: z.number().int().openapi({ example: 0 }),
+    createdAt: z.iso.datetime().openapi({ example: "2024-01-15T10:00:00Z" }),
+    updatedAt: z.iso.datetime().openapi({ example: "2024-01-16T12:00:00Z" }),
+  })
+  .openapi("FieldOption");
+
+export const FieldSchema = z
+  .object({
+    id: z.string().openapi({ example: "cryitfjp7890yz12abcdefg" }),
+    key: z.string().openapi({ example: "audience" }),
+    name: z.string().openapi({ example: "Audience" }),
+    description: z
+      .string()
+      .nullable()
+      .openapi({ example: "Who this post is for" }),
+    type: FieldTypeSchema,
+    required: z.boolean().openapi({ example: false }),
+    position: z.number().int().openapi({ example: 0 }),
+    options: z.array(FieldOptionSchema),
+    createdAt: z.iso.datetime().openapi({ example: "2024-01-15T10:00:00Z" }),
+    updatedAt: z.iso.datetime().openapi({ example: "2024-01-16T12:00:00Z" }),
+  })
+  .openapi("Field");
+
+export const FieldsListResponseSchema = z
+  .object({
+    fields: z.array(FieldSchema),
+  })
+  .openapi("FieldsListResponse");
+
+export const FieldResponseSchema = z
+  .object({
+    field: FieldSchema,
+  })
+  .openapi("FieldResponse");
+
+export const FieldOptionInputSchema = z
+  .object({
+    value: z
+      .string()
+      .trim()
+      .min(1, "Option value cannot be empty")
+      .max(80, "Option value cannot be more than 80 characters")
+      .openapi({ example: "developers" }),
+    label: z
+      .string()
+      .trim()
+      .min(1, "Option label cannot be empty")
+      .max(80, "Option label cannot be more than 80 characters")
+      .openapi({ example: "Developers" }),
+  })
+  .openapi("FieldOptionInput");
+
+export const FieldOptionsInputSchema = z
+  .array(FieldOptionInputSchema)
+  .max(100, "Fields cannot have more than 100 options");
+
+function validateUniqueOptionValues(
+  options: Array<{ value: string; label: string }>,
+  ctx: z.RefinementCtx
+) {
+  const seenValues = new Set<string>();
+
+  for (const [index, option] of options.entries()) {
+    if (seenValues.has(option.value)) {
+      ctx.addIssue({
+        code: "custom",
+        message: "Option values must be unique",
+        path: ["options", index, "value"],
+      });
+      continue;
+    }
+
+    seenValues.add(option.value);
+  }
+}
+
+function validateFieldOptions(
+  type: z.infer<typeof FieldTypeSchema>,
+  options: Array<{ value: string; label: string }>,
+  ctx: z.RefinementCtx
+) {
+  const requiresOptions = type === "select" || type === "multiselect";
+
+  if (requiresOptions && options.length === 0) {
+    ctx.addIssue({
+      code: "custom",
+      message: "Select fields must define at least one option",
+      path: ["options"],
+    });
+  }
+
+  if (!requiresOptions && options.length > 0) {
+    ctx.addIssue({
+      code: "custom",
+      message: "Only select and multiselect fields can define options",
+      path: ["options"],
+    });
+  }
+
+  validateUniqueOptionValues(options, ctx);
+}
+
+export const CreateFieldBodySchema = z
+  .object({
+    key: z
+      .string()
+      .min(1, "Key cannot be empty")
+      .max(50, "Key cannot be more than 50 characters")
+      .regex(/^[a-z0-9_]+$/, {
+        message:
+          "Key can only contain lowercase letters, numbers, and underscores",
+      })
+      .openapi({ example: "audience" }),
+    name: z
+      .string()
+      .min(1, "Name cannot be empty")
+      .max(50, "Name cannot be more than 50 characters")
+      .openapi({ example: "Audience" }),
+    description: z
+      .string()
+      .max(280, "Description cannot be more than 280 characters")
+      .optional()
+      .openapi({ example: "Who this post is for" }),
+    type: FieldTypeSchema,
+    required: z.boolean().optional().openapi({ example: false }),
+    options: FieldOptionsInputSchema.optional().openapi({
+      description:
+        "Required for select and multiselect fields. Not allowed for other field types.",
+      example: [
+        { value: "developers", label: "Developers" },
+        { value: "founders", label: "Founders" },
+      ],
+    }),
+  })
+  .superRefine((value, ctx) => {
+    validateFieldOptions(value.type, value.options ?? [], ctx);
+  })
+  .openapi("CreateFieldBody");
+
+export const UpdateFieldBodySchema = z
+  .object({
+    key: z
+      .string()
+      .min(1, "Key cannot be empty")
+      .max(50, "Key cannot be more than 50 characters")
+      .regex(/^[a-z0-9_]+$/, {
+        message:
+          "Key can only contain lowercase letters, numbers, and underscores",
+      })
+      .optional()
+      .openapi({ example: "audience" }),
+    name: z
+      .string()
+      .min(1, "Name cannot be empty")
+      .max(50, "Name cannot be more than 50 characters")
+      .optional()
+      .openapi({ example: "Audience" }),
+    description: z
+      .string()
+      .max(280, "Description cannot be more than 280 characters")
+      .nullable()
+      .optional()
+      .openapi({ example: "Who this post is for" }),
+    type: FieldTypeSchema.optional(),
+    required: z.boolean().optional().openapi({ example: false }),
+    options: FieldOptionsInputSchema.optional().openapi({
+      description:
+        "Replacement option list. Only valid for select and multiselect fields.",
+      example: [
+        { value: "developers", label: "Developers" },
+        { value: "founders", label: "Founders" },
+      ],
+    }),
+  })
+  .superRefine((value, ctx) => {
+    if (value.options !== undefined) {
+      validateUniqueOptionValues(value.options, ctx);
+    }
+  })
+  .openapi("UpdateFieldBody");

--- a/apps/api/src/schemas/fields.ts
+++ b/apps/api/src/schemas/fields.ts
@@ -133,6 +133,7 @@ export const CreateFieldBodySchema = z
       .openapi({ example: "audience" }),
     name: z
       .string()
+      .trim()
       .min(1, "Name cannot be empty")
       .max(50, "Name cannot be more than 50 characters")
       .openapi({ example: "Audience" }),
@@ -171,6 +172,7 @@ export const UpdateFieldBodySchema = z
       .openapi({ example: "audience" }),
     name: z
       .string()
+      .trim()
       .min(1, "Name cannot be empty")
       .max(50, "Name cannot be more than 50 characters")
       .optional()

--- a/apps/api/src/schemas/posts.ts
+++ b/apps/api/src/schemas/posts.ts
@@ -92,6 +92,28 @@ export const PostSchema = z
   })
   .openapi("Post");
 
+const CustomFieldWriteValueSchema = z.union([
+  z.string(),
+  z.number(),
+  z.boolean(),
+  z.array(z.string()),
+  z.null(),
+]);
+
+const CustomFieldsWriteSchema = z
+  .record(z.string(), CustomFieldWriteValueSchema)
+  .openapi({
+    description:
+      "Custom field values keyed by field key. Select values must use option values; multiselect values must be arrays of option values. Use null to clear optional fields.",
+    example: {
+      release_date: "2024-01-15",
+      priority_score: 5,
+      audience: ["developers", "founders"],
+      featured_customer: true,
+      subtitle: null,
+    },
+  });
+
 export const PostsListResponseSchema = z
   .object({
     posts: z.array(PostSchema),
@@ -330,6 +352,7 @@ export const CreatePostBodySchema = z
       example: "2024-01-15T10:00:00Z",
       description: "ISO 8601 datetime. Defaults to current time if omitted.",
     }),
+    fields: CustomFieldsWriteSchema.optional(),
   })
   .openapi("CreatePostBody");
 
@@ -405,6 +428,7 @@ export const UpdatePostBodySchema = z
       .datetime()
       .optional()
       .openapi({ example: "2024-02-01T10:00:00Z" }),
+    fields: CustomFieldsWriteSchema.optional(),
   })
   .openapi("UpdatePostBody");
 

--- a/apps/docs/features/custom-fields.mdx
+++ b/apps/docs/features/custom-fields.mdx
@@ -30,6 +30,11 @@ Custom fields let you add your own metadata to every post in a workspace. Instea
   </Step>
 </Steps>
 
+You can also manage field definitions through the API, SDK, or MCP server.
+Agents should call `get_fields` before writing post field values, create any
+missing field with `create_field`, then pass values under `fields` when creating
+or updating a post.
+
 ## Field types
 
 | Type | Input in Marble | API value |
@@ -44,8 +49,44 @@ Custom fields let you add your own metadata to every post in a workspace. Instea
 
 <Note>
   `select` and `multiselect` fields require predefined options. Option values
-  are what you receive in the API.
+  are what you receive in the API and what you send when writing post values.
 </Note>
+
+## Writing fields through the API
+
+Create field definitions first:
+
+```json
+{
+  "key": "audience",
+  "name": "Audience",
+  "type": "multiselect",
+  "required": false,
+  "options": [
+    { "value": "developers", "label": "Developers" },
+    { "value": "founders", "label": "Founders" }
+  ]
+}
+```
+
+Then pass values by field key when creating or updating posts:
+
+```json
+{
+  "title": "Launch Notes",
+  "content": "<p>Hello world</p>",
+  "description": "What changed this week",
+  "slug": "launch-notes",
+  "categoryId": "cat_123",
+  "status": "draft",
+  "fields": {
+    "audience": ["developers", "founders"]
+  }
+}
+```
+
+Unknown field keys, wrong value types, and option values that do not match a
+configured `select` or `multiselect` option are rejected with `400` responses.
 
 ## API response shape
 
@@ -87,5 +128,7 @@ If a field exists in your workspace but a post has no value for it yet, Marble r
 ## Important behavior
 
 - Field keys are workspace-scoped and must be unique.
+- Post writes never create fields implicitly. Create or update field definitions
+  first, then write values to posts.
 - Field type and options are effectively schema choices. Plan them early to avoid migration work later.
 - Deleting a field removes that field and its stored values from all posts.

--- a/apps/docs/tools/mcp.mdx
+++ b/apps/docs/tools/mcp.mdx
@@ -248,6 +248,16 @@ Tool badges describe how clients may present or approve tool calls:
     | `update_media` | Update media metadata such as name and alt text. Requires a private API key. | `DESTRUCTIVE` |
     | `delete_media` | Delete a media asset and its stored file. Requires a private API key. | `DESTRUCTIVE` |
   </Accordion>
+
+  <Accordion title="Fields">
+    | Tool | Description | Badges |
+    | --- | --- | --- |
+    | `get_fields` | Get all custom field definitions, including select and multiselect options. | `READ-ONLY` |
+    | `get_field` | Get a single custom field by ID or key. | `READ-ONLY` |
+    | `create_field` | Create a custom field definition. Requires a private API key. |  |
+    | `update_field` | Update a custom field by ID or key. Type and options cannot be changed after values have been saved. Requires a private API key. | `DESTRUCTIVE` |
+    | `delete_field` | Delete a custom field and its saved values. Requires a private API key. | `DESTRUCTIVE` |
+  </Accordion>
 </AccordionGroup>
 
 ## Authentication

--- a/apps/docs/tools/sdk.mdx
+++ b/apps/docs/tools/sdk.mdx
@@ -93,6 +93,12 @@ const marble = new Marble({
   - List all authors
   - Get a single author
 </Card>
+
+<Card title="Fields" icon="sliders-horizontal">
+  - List custom fields
+  - Create and update field definitions
+  - Write field values on posts
+</Card>
 </CardGroup>
 
 ## Filtering Posts

--- a/apps/mcp/src/server.ts
+++ b/apps/mcp/src/server.ts
@@ -2,6 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { getServerInstructions } from "@/lib/instructions";
 import { registerAuthorTools } from "@/tools/authors";
 import { registerCategoryTools } from "@/tools/categories";
+import { registerFieldTools } from "@/tools/fields";
 import { registerMediaTools } from "@/tools/media";
 import { registerPostTools } from "@/tools/posts";
 import { registerTagTools } from "@/tools/tags";
@@ -22,6 +23,7 @@ export function createServer(apiBaseUrl: string, apiKey: string) {
   registerTagTools(server, apiBaseUrl, apiKey);
   registerAuthorTools(server, apiBaseUrl, apiKey);
   registerMediaTools(server, apiBaseUrl, apiKey);
+  registerFieldTools(server, apiBaseUrl, apiKey);
 
   return server;
 }

--- a/apps/mcp/src/tools/fields.ts
+++ b/apps/mcp/src/tools/fields.ts
@@ -1,0 +1,164 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { deleteJsonApi, readJsonApi, writeJsonApi } from "@/lib/api";
+import { toolResult } from "@/lib/mcp";
+import {
+  destructiveAnnotations,
+  identifierInput,
+  readOnlyAnnotations,
+} from "./shared";
+
+const fieldType = z.enum([
+  "text",
+  "number",
+  "boolean",
+  "date",
+  "richtext",
+  "select",
+  "multiselect",
+]);
+
+const fieldOption = z.object({
+  value: z
+    .string()
+    .min(1)
+    .describe("Stable option value used in post field payloads."),
+  label: z.string().min(1).describe("Human-readable option label."),
+});
+
+const fieldBody = {
+  key: z
+    .string()
+    .regex(/^[a-z0-9_]+$/)
+    .describe(
+      "Stable field key, using lowercase letters, numbers, and underscores."
+    ),
+  name: z.string().min(1).describe("Display name."),
+  description: z.string().optional().describe("Optional field description."),
+  type: fieldType.describe("Custom field type."),
+  required: z
+    .boolean()
+    .optional()
+    .describe("Whether posts must set this field."),
+  options: z
+    .array(fieldOption)
+    .optional()
+    .describe(
+      "Required for select and multiselect fields. Not allowed for other field types."
+    ),
+};
+
+const updateFieldBody = {
+  key: z
+    .string()
+    .regex(/^[a-z0-9_]+$/)
+    .optional()
+    .describe("Updated stable field key."),
+  name: z.string().min(1).optional().describe("Updated display name."),
+  description: z
+    .string()
+    .nullable()
+    .optional()
+    .describe("Updated field description. Use null to clear it."),
+  type: fieldType.optional().describe("Updated field type."),
+  required: z.boolean().optional().describe("Updated required flag."),
+  options: z
+    .array(fieldOption)
+    .optional()
+    .describe("Replacement options for select and multiselect fields."),
+};
+
+export function registerFieldTools(
+  server: McpServer,
+  apiBaseUrl: string,
+  apiKey: string
+) {
+  server.registerTool(
+    "get_fields",
+    {
+      title: "Get Fields",
+      description:
+        "Get all custom field definitions. Use this before writing post fields so you can use valid field keys and option values.",
+      annotations: readOnlyAnnotations,
+      inputSchema: {},
+    },
+    async () => toolResult(await readJsonApi(apiBaseUrl, apiKey, "/v1/fields"))
+  );
+
+  server.registerTool(
+    "get_field",
+    {
+      title: "Get Field",
+      description: "Get a single custom field definition by ID or key.",
+      annotations: readOnlyAnnotations,
+      inputSchema: identifierInput,
+    },
+    async ({ identifier }) =>
+      toolResult(
+        await readJsonApi(
+          apiBaseUrl,
+          apiKey,
+          `/v1/fields/${encodeURIComponent(identifier)}`
+        )
+      )
+  );
+
+  server.registerTool(
+    "create_field",
+    {
+      title: "Create Field",
+      description:
+        "Create a custom field definition. Requires a private Marble API key. Create fields before using their keys in create_post or update_post.",
+      inputSchema: {
+        body: z.object(fieldBody),
+      },
+    },
+    async ({ body }) =>
+      toolResult(
+        await writeJsonApi(apiBaseUrl, apiKey, "POST", "/v1/fields", body)
+      )
+  );
+
+  server.registerTool(
+    "update_field",
+    {
+      title: "Update Field",
+      description:
+        "Update a custom field by ID or key. Type and options cannot be changed after values have been saved. Requires a private Marble API key.",
+      annotations: destructiveAnnotations,
+      inputSchema: {
+        ...identifierInput,
+        body: z.object(updateFieldBody),
+      },
+    },
+    async ({ identifier, body }) =>
+      toolResult(
+        await writeJsonApi(
+          apiBaseUrl,
+          apiKey,
+          "PATCH",
+          `/v1/fields/${encodeURIComponent(identifier)}`,
+          body
+        )
+      )
+  );
+
+  server.registerTool(
+    "delete_field",
+    {
+      title: "Delete Field",
+      description:
+        "Delete a custom field by ID or key. This also deletes saved values for that field. Requires a private Marble API key.",
+      annotations: destructiveAnnotations,
+      inputSchema: identifierInput,
+    },
+    async ({ identifier }) =>
+      toolResult(
+        await deleteJsonApi(
+          apiBaseUrl,
+          apiKey,
+          `/v1/fields/${encodeURIComponent(identifier)}`
+        )
+      )
+  );
+}

--- a/apps/mcp/src/tools/posts.ts
+++ b/apps/mcp/src/tools/posts.ts
@@ -38,6 +38,20 @@ const postFilters = {
     .describe("Tag IDs or slugs to exclude."),
 };
 
+const customFieldValue = z.union([
+  z.string(),
+  z.number(),
+  z.boolean(),
+  z.array(z.string()),
+  z.null(),
+]);
+
+const customFields = z
+  .record(z.string(), customFieldValue)
+  .describe(
+    "Custom field values keyed by field key. Call get_fields first. Select values must use option values, multiselect values must be arrays of option values, and null clears optional fields."
+  );
+
 const postBody = {
   title: z.string().min(1).describe("Post title."),
   content: z
@@ -75,6 +89,7 @@ const postBody = {
     .datetime()
     .optional()
     .describe("ISO 8601 datetime. Defaults to current time if omitted."),
+  fields: customFields.optional(),
 };
 
 const updatePostBody = {
@@ -121,6 +136,7 @@ const updatePostBody = {
     .datetime()
     .optional()
     .describe("Updated ISO 8601 publication datetime."),
+  fields: customFields.optional(),
 };
 
 export function registerPostTools(

--- a/packages/db/src/workers.ts
+++ b/packages/db/src/workers.ts
@@ -1,5 +1,10 @@
 import { PrismaNeon } from "@prisma/adapter-neon";
-import { PrismaClient } from "./generated/workerd/client";
+import {
+  PrismaClient,
+  Prisma as WorkerdPrisma,
+} from "./generated/workerd/client";
+
+const Prisma = WorkerdPrisma;
 
 const createClient = (url: string) => {
   const connectionString =
@@ -12,4 +17,4 @@ const createClient = (url: string) => {
   const adapter = new PrismaNeon({ connectionString });
   return new PrismaClient({ adapter });
 };
-export { createClient };
+export { createClient, Prisma };


### PR DESCRIPTION
## Description

Adds first-class custom field support to the public API and MCP server. This includes `/v1/fields` read/write endpoints, OpenAPI schemas for field definitions and options, key-based custom field validation for post create/update, MCP field tools, and docs updates for the API/SDK/MCP workflow.

## Motivation and Context

Custom fields already existed in the data model and were returned on post reads, but field definitions and post field writes were not exposed through the public API or MCP server. This lets agents and SDK/API users deliberately create field definitions, validate post field payloads against existing schema, and write custom field values without implicit schema creation.

## How to Test

1. Run `pnpm lint`.
2. Run `pnpm exec tsc -p apps/mcp/tsconfig.json --noEmit`.
3. Start the API locally with Wrangler.
4. Verify public keys can read fields but cannot write them.
5. Verify invalid field definitions return structured `400` responses.
6. Create select, multiselect, and required text fields with a private key.
7. Verify post creation rejects unknown field keys, invalid select values, invalid multiselect values, and missing required fields.
8. Verify valid post creation stores custom field values and post readback returns typed values.
9. Verify post update can clear optional field values with `null`.
10. Verify changing a field type/options is blocked after values exist.

Validation performed locally:

- `pnpm lint`
- `pnpm exec tsc -p apps/mcp/tsconfig.json --noEmit`
- Local Wrangler API validation suite covering field permissions, bad payloads, valid post writes, typed readback, update validation, unsafe schema changes, and cleanup
- Local smoke test confirming field validation errors return `{ error, message, details }`

## Screenshots (if applicable)

N/A

## Video Demo (if applicable)

N/A

## Types of Changes

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that alters existing functionality)
- [ ] 🎨 UI/UX Improvements
- [ ] ⚡ Performance Enhancement
- [x] 📖 Documentation (updates to README, docs, or comments)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Added workspace-scoped custom fields API with full CRUD for field definitions, including select/multiselect option support and structured validation errors.
* Posts now accept custom field values on create/update, persisting them transactionally.
* Added MCP tools for listing, fetching, creating, updating, and deleting custom fields.

## Documentation
* Expanded custom fields docs with API/SDK/MCP workflows and JSON examples for defining fields and writing values.

## Bug Fixes
* Improved cache invalidation to include custom fields (so updates reflect correctly).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->