### PR TITLE
Recover stale webhook deliveries

### DIFF
--- a/apps/jobs/package.json
+++ b/apps/jobs/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "wrangler deploy --minify",
-    "cf-typegen": "wrangler types --env-interface CloudflareBindings"
+    "cf-typegen": "wrangler types --env-interface CloudflareBindings",
+    "test": "vitest run"
   },
   "dependencies": {
     "@marble/db": "workspace:*",
@@ -20,6 +21,7 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260508.1",
+    "vitest": "^3.2.4",
     "wrangler": "^4.90.0"
   }
 }

--- a/apps/jobs/src/consumers/deliveries.test.ts
+++ b/apps/jobs/src/consumers/deliveries.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@marble/events", () => ({
+  buildWebhookPayload: vi.fn(),
+  serializeEventType: vi.fn(),
+}));
+vi.mock("@/lib/db", () => ({ createDbClient: vi.fn() }));
+vi.mock("@/lib/formats", () => ({ buildWebhookRequestBody: vi.fn() }));
+vi.mock("@/lib/signing", () => ({ signPayload: vi.fn() }));
+vi.mock("@/lib/usage", () => ({
+  checkWebhookUsage: vi.fn(),
+  recordWebhookUsage: vi.fn(),
+  sendWebhookUsageAlert: vi.fn(),
+}));
+
+import { WEBHOOK_DELIVERY_STALE_SENDING_MS } from "@/lib/constants";
+import { claimWebhookDeliveryAttempt } from "./deliveries";
+
+function createDb({
+  activeClaimCount,
+  staleClaimCount,
+  status,
+}: {
+  activeClaimCount: number;
+  staleClaimCount: number;
+  status?: string;
+}) {
+  const updateMany = vi
+    .fn()
+    .mockResolvedValueOnce({ count: activeClaimCount })
+    .mockResolvedValueOnce({ count: staleClaimCount });
+  const findUnique = vi
+    .fn()
+    .mockResolvedValue(status === undefined ? null : { status });
+
+  return {
+    webhookDelivery: {
+      updateMany,
+      findUnique,
+    },
+  };
+}
+
+describe("claimWebhookDeliveryAttempt", () => {
+  it("claims pending or retrying deliveries for a new attempt", async () => {
+    const now = new Date("2026-06-30T12:00:00.000Z");
+    const db = createDb({ activeClaimCount: 1, staleClaimCount: 0 });
+
+    await expect(
+      claimWebhookDeliveryAttempt(db as never, "delivery_1", now)
+    ).resolves.toBe(true);
+
+    expect(db.webhookDelivery.updateMany).toHaveBeenCalledTimes(1);
+    expect(db.webhookDelivery.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: "delivery_1",
+        status: { in: ["pending", "retrying"] },
+      },
+      data: {
+        status: "sending",
+        attemptCount: { increment: 1 },
+        lastAttemptAt: now,
+      },
+    });
+    expect(db.webhookDelivery.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("reclaims stale sending deliveries instead of acknowledging them", async () => {
+    const now = new Date("2026-06-30T12:00:00.000Z");
+    const db = createDb({ activeClaimCount: 0, staleClaimCount: 1 });
+
+    await expect(
+      claimWebhookDeliveryAttempt(db as never, "delivery_1", now)
+    ).resolves.toBe(true);
+
+    expect(db.webhookDelivery.updateMany).toHaveBeenCalledTimes(2);
+    expect(db.webhookDelivery.updateMany).toHaveBeenNthCalledWith(2, {
+      where: {
+        id: "delivery_1",
+        status: "sending",
+        OR: [
+          {
+            lastAttemptAt: {
+              lt: new Date(
+                now.getTime() - WEBHOOK_DELIVERY_STALE_SENDING_MS
+              ),
+            },
+          },
+          { lastAttemptAt: null },
+        ],
+      },
+      data: {
+        status: "sending",
+        attemptCount: { increment: 1 },
+        lastAttemptAt: now,
+      },
+    });
+    expect(db.webhookDelivery.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("keeps active sending deliveries on the queue retry path", async () => {
+    const now = new Date("2026-06-30T12:00:00.000Z");
+    const db = createDb({
+      activeClaimCount: 0,
+      staleClaimCount: 0,
+      status: "sending",
+    });
+
+    await expect(
+      claimWebhookDeliveryAttempt(db as never, "delivery_1", now)
+    ).rejects.toThrow("Webhook delivery delivery_1 is already sending");
+  });
+
+  it("skips terminal or missing deliveries", async () => {
+    const now = new Date("2026-06-30T12:00:00.000Z");
+    const db = createDb({
+      activeClaimCount: 0,
+      staleClaimCount: 0,
+      status: "success",
+    });
+
+    await expect(
+      claimWebhookDeliveryAttempt(db as never, "delivery_1", now)
+    ).resolves.toBe(false);
+  });
+});

--- a/apps/jobs/src/consumers/deliveries.ts
+++ b/apps/jobs/src/consumers/deliveries.ts
@@ -1,5 +1,8 @@
 import { buildWebhookPayload, serializeEventType } from "@marble/events";
-import { WEBHOOK_DELIVERY_TIMEOUT_MS } from "@/lib/constants";
+import {
+  WEBHOOK_DELIVERY_STALE_SENDING_MS,
+  WEBHOOK_DELIVERY_TIMEOUT_MS,
+} from "@/lib/constants";
 import { createDbClient } from "@/lib/db";
 import { buildWebhookRequestBody } from "@/lib/formats";
 import { signPayload } from "@/lib/signing";
@@ -37,19 +40,9 @@ async function processDelivery(
   env: Env,
   deliveryId: string
 ) {
-  const claim = await db.webhookDelivery.updateMany({
-    where: {
-      id: deliveryId,
-      status: { in: ["pending", "retrying"] },
-    },
-    data: {
-      status: "sending",
-      attemptCount: { increment: 1 },
-      lastAttemptAt: new Date(),
-    },
-  });
+  const claimed = await claimWebhookDeliveryAttempt(db, deliveryId);
 
-  if (claim.count === 0) {
+  if (!claimed) {
     return;
   }
 
@@ -219,4 +212,57 @@ async function processDelivery(
   });
 
   throw new Error(`Webhook returned ${response.status}`);
+}
+
+export async function claimWebhookDeliveryAttempt(
+  db: ReturnType<typeof createDbClient>,
+  deliveryId: string,
+  now = new Date()
+) {
+  const claim = await db.webhookDelivery.updateMany({
+    where: {
+      id: deliveryId,
+      status: { in: ["pending", "retrying"] },
+    },
+    data: {
+      status: "sending",
+      attemptCount: { increment: 1 },
+      lastAttemptAt: now,
+    },
+  });
+
+  if (claim.count > 0) {
+    return true;
+  }
+
+  const staleCutoff = new Date(
+    now.getTime() - WEBHOOK_DELIVERY_STALE_SENDING_MS
+  );
+  const staleClaim = await db.webhookDelivery.updateMany({
+    where: {
+      id: deliveryId,
+      status: "sending",
+      OR: [{ lastAttemptAt: { lt: staleCutoff } }, { lastAttemptAt: null }],
+    },
+    data: {
+      status: "sending",
+      attemptCount: { increment: 1 },
+      lastAttemptAt: now,
+    },
+  });
+
+  if (staleClaim.count > 0) {
+    return true;
+  }
+
+  const delivery = await db.webhookDelivery.findUnique({
+    where: { id: deliveryId },
+    select: { status: true },
+  });
+
+  if (delivery?.status === "sending") {
+    throw new Error(`Webhook delivery ${deliveryId} is already sending`);
+  }
+
+  return false;
 }

--- a/apps/jobs/src/lib/constants.ts
+++ b/apps/jobs/src/lib/constants.ts
@@ -8,6 +8,8 @@ export const IMPORT_JOB_RETENTION_DAYS = 30;
 export const IMPORT_STALE_JOB_DAYS = 1;
 export const WEBHOOK_DELIVERY_RETENTION_DAYS = 30;
 export const WEBHOOK_DELIVERY_TIMEOUT_MS = 15_000;
+export const WEBHOOK_DELIVERY_STALE_SENDING_MS =
+  WEBHOOK_DELIVERY_TIMEOUT_MS * 2;
 // The dashboard currently renders a 30-day chart plus the previous 30-day
 // comparison from raw API request rows.
 export const API_REQUEST_RETENTION_DAYS = 60;

--- a/apps/jobs/vitest.config.mjs
+++ b/apps/jobs/vitest.config.mjs
@@ -1,0 +1,16 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+const root = dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": resolve(root, "src"),
+    },
+  },
+  test: {
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -339,6 +339,9 @@ importers:
       '@cloudflare/workers-types':
         specifier: ^4.20260508.1
         version: 4.20260626.1
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
       wrangler:
         specifier: ^4.90.0
         version: 4.105.0(@cloudflare/workers-types@4.20260626.1)(bufferutil@4.1.0)


### PR DESCRIPTION
## Description

This updates the webhook delivery worker so queue retries can recover delivery rows that were left in `sending` by an interrupted attempt.

Changes included:

- Reclaim stale `sending` deliveries after the outbound delivery timeout window.
- Keep active `sending` deliveries on the queue retry path instead of acknowledging a skipped delivery.
- Preserve existing behavior for terminal or missing deliveries.
- Add focused worker tests for normal claims, stale `sending` recovery, active `sending` retry behavior, and terminal delivery skips.

## Motivation and Context

The delivery worker marks a `webhookDelivery` row as `sending` before making the outbound POST. If the worker is interrupted before it records the attempt result and final status, the next queue delivery sees the row in `sending`. Previously that failed the `pending`/`retrying` claim and returned successfully, which acknowledged the queue message while leaving the row permanently in progress.

This keeps the current durable claim model, but makes `sending` recoverable once the prior attempt is stale. Non-stale `sending` rows still retry later, which avoids treating an actively owned delivery as complete.

## How to Test

Passed locally:

```bash
corepack pnpm --filter jobs test
corepack pnpm --filter @marble/db db:generate
corepack pnpm exec tsc -p apps/jobs/tsconfig.json --noEmit
git diff --check
corepack pnpm test
```

Local blockers unrelated to this patch:

```bash
corepack pnpm lint
```

The root lint script invokes `pnpx`, which is not available in the pinned Corepack pnpm environment. Running the equivalent `corepack pnpm exec ultracite check` reaches the existing root `biome.jsonc` and stops on unknown config keys `noShadow` and `noUnnecessaryConditions` before checking changed files.

```bash
corepack pnpm build
```

The full build stops in `web#build` because the local environment does not define `MARBLE_API_KEY` for the Astro content config.

## Screenshots (if applicable)

N/A

## Video Demo (if applicable)

N/A

## Types of Changes

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that alters existing functionality)
- [ ] 🎨 UI/UX Improvements
- [ ] ⚡ Performance Enhancement
- [ ] 📖 Documentation (updates to README, docs, or comments)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of webhook delivery handling, including better recovery from stuck in-progress deliveries.
  * Prevents duplicate processing when a delivery is already actively being sent.
  * Keeps completed deliveries from being retried incorrectly.

* **Tests**
  * Added test coverage for delivery claim scenarios to validate pending, retrying, stale, active, and completed states.

* **Chores**
  * Added test tooling and configuration for the jobs package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->